### PR TITLE
[examples] add CRON example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,63 @@
-# AWS Access Key for authenticating AWS services
-AWS_ACCESS_KEY=000000000000000000000
+# Environment Configuration Template for MariaDB Backup to S3
+# Copy this file to .env and fill in your actual values
+# This file contains all required environment variables with examples and documentation
 
-# AWS region where the services are hosted
-AWS_REGION=us-east-1
+# =============================================================================
+# MARIADB CONFIGURATION
+# =============================================================================
 
-# AWS Secret Key for authenticating AWS services
-AWS_SECRET_KEY=000000000000000000000
+# MariaDB Host
+# Purpose: Hostname or IP address of the MariaDB server
+# Format: string
+# Default: localhost
+# Example: localhost
+# Example: db.example.com
+MARIADB__HOST=localhost
 
-# MariaDB username for database authentication
+# MariaDB Port
+# Purpose: Port number for MariaDB connection
+# Format: integer
+# Default: 3306
+# Example: 3306
+MARIADB__PORT=3306
+
+# MariaDB Username
+# Purpose: Username for authenticating with MariaDB
+# Format: string
+# Default: root
+# Example: backup_user
 MARIADB__USER=root
 
-# MariaDB password for database authentication
-MARIADB__PASSWORD=000000
+# MariaDB Password
+# Purpose: Password for authenticating with MariaDB
+# Format: string
+# Example: secure_password
+MARIADB__PASSWORD=secure_password
 
-# URL for storage service, including bucket name and endpoint
-STORAGE__URL=s3://bucket-name/prefix?endpoint=http://127.0.0.1:9000&force_path_style=true
+# MariaDB Backup Options
+# Purpose: Additional options for the mariabackup command
+# Format: string
+# Example: "--parallel=4"
+MARIADB__BACKUP_OPTIONS=
+
+# =============================================================================
+# STORAGE CONFIGURATION
+# =============================================================================
+
+# Storage URL
+# Purpose: URL for storage destination (supports s3://, file://)
+# Format: URL string
+# Example: s3://my-bucket/backups?endpoint=https://s3.custom.com
+# Example: file:///var/backups
+STORAGE__URL=
+
+# =============================================================================
+# BACKUP LIMITS CONFIGURATION
+# =============================================================================
+
+# Maximum Backup Count
+# Purpose: Maximum number of backups to retain (0 = unlimited)
+# Format: integer
+# Default: 0
+# Example: 7
+BACKUP__LIMITS__MAX_COUNT=0

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@
     - [Command Line](#command-line)
     - [Docker](#docker-1)
   - [⏰ Scheduling](#-scheduling)
-    - [systemd Service Example](#systemd-service-example)
-    - [Docker Swarm Example](#docker-swarm-example)
   - [🤝 Contributing](#-contributing)
   - [📄 License](#-license)
 
@@ -133,15 +131,15 @@ AWS_REGION=us-east-1
 BACKUP__LIMITS__MAX_COUNT=30  # Keep last 30 backups
 ```
 
-| Variable                    | Default      | Description                          |
-| --------------------------- | ------------ | ------------------------------------ |
-| `MARIADB__HOST`             | localhost    | Database host address                |
-| `MARIADB__PORT`             | 3306         | Database port                        |
-| `MARIADB__USER`             | root         | Database user                        |
-| `MARIADB__PASSWORD`         | -            | Database password                    |
-| `MARIADB__BACKUP_OPTIONS`   | -            | Extra `mariabackup` options          |
-| `STORAGE__URL`              | **Required** | Storage URL (format depends on type) |
-| `BACKUP__LIMITS__MAX_COUNT` | 30           | Maximum backups to retain            |
+| Variable                    | Default       | Description                          |
+| --------------------------- | ------------- | ------------------------------------ |
+| `MARIADB__HOST`             | localhost     | Database host address                |
+| `MARIADB__PORT`             | 3306          | Database port                        |
+| `MARIADB__USER`             | root          | Database user                        |
+| `MARIADB__PASSWORD`         | -             | Database password                    |
+| `MARIADB__BACKUP_OPTIONS`   | -             | Extra `mariabackup` options          |
+| `STORAGE__URL`              | **Required**  | Storage URL (format depends on type) |
+| `BACKUP__LIMITS__MAX_COUNT` | 0 (unlimited) | Maximum backups to retain            |
 
 ### Command-Line Flags
 Override any configuration with flags:
@@ -221,13 +219,10 @@ docker run --rm \
 
 ## ⏰ Scheduling
 
-### systemd Service Example
-
-For running as a scheduled service on Linux, see the [systemd example](./examples/systemd-service).
-
-### Docker Swarm Example
-
-The example can be found in [examples/docker-cron-backup](./examples/docker-cron-backup/compose.yml)
+- **systemd Service Example**: [examples/systemd-service](./examples/systemd-service/)
+- **Docker Swarm CRON Example**: [examples/docker-cron-backup](./examples/docker-cron-backup/)
+- **Simple CRON Example**: [examples/simple-cron-backup](./examples/simple-cron-backup/)
+- **Advanced CRON Example**: [examples/advanced-cron-backup](./examples/advanced-cron-backup/)
 
 ## 🤝 Contributing
 

--- a/examples/advanced-cron-backup/README.md
+++ b/examples/advanced-cron-backup/README.md
@@ -1,0 +1,200 @@
+# CRON Backup Example
+
+This example demonstrates how to set up automated MariaDB backups using system CRON with the mariadb-backup-s3 tool.
+
+## 📁 Files Structure
+
+```
+examples/cron-backup/
+├── README.md              # This file
+├── backup.sh             # Backup script wrapper
+├── crontab.example       # Example crontab configuration
+└── backup.env.example    # Environment variables template
+```
+
+## 🚀 Setup Instructions
+
+### 1. Create Environment File
+
+Copy the environment template and customize it:
+
+```bash
+cp backup.env.example backup.env
+nano backup.env
+```
+
+### 2. Make Backup Script Executable
+
+```bash
+chmod +x backup.sh
+```
+
+### 3. Install CRON Job
+
+Choose one of the following methods:
+
+#### Method A: Install to System Crontab
+
+```bash
+# Edit system crontab
+sudo crontab -e
+
+# Add the following line (adjust paths as needed):
+0 2 * * * /path/to/mariadb-backup-s3/examples/cron-backup/backup.sh
+```
+
+#### Method B: Install to User Crontab
+
+```bash
+# Edit user crontab
+crontab -e
+
+# Add the following line (adjust paths as needed):
+0 2 * * * /path/to/mariadb-backup-s3/examples/cron-backup/backup.sh
+```
+
+#### Method C: Use the Example Crontab
+
+```bash
+# Copy and install the example crontab
+cp crontab.example /tmp/my-crontab
+crontab /tmp/my-crontab
+rm /tmp/my-crontab
+```
+
+## ⏰ CRON Schedule Examples
+
+The `crontab.example` file includes several common backup schedules:
+
+```bash
+# Daily backup at 2 AM
+0 2 * * * /path/to/backup.sh
+
+# Weekly backup on Sunday at 3 AM
+0 3 * * 0 /path/to/backup.sh
+
+# Monthly backup on the 1st at 4 AM
+0 4 1 * * /path/to/backup.sh
+
+# Every 6 hours
+0 */6 * * * /path/to/backup.sh
+```
+
+## 📧 Logging and Notifications
+
+The backup script includes logging functionality. By default, logs are written to:
+
+- `/var/log/mariadb-backup.log` - Main backup log
+- `/var/log/mariadb-backup-error.log` - Error log
+
+To enable email notifications on failure, ensure your system has a working `mail` command and set `NOTIFY_EMAIL` in `backup.env`. Example:
+
+```bash
+NOTIFY_EMAIL="admin@example.com"
+```
+
+## 🔧 Customization
+
+### Environment Variables
+
+Edit `backup.env` to match your database and storage configuration:
+
+```bash
+# MariaDB Configuration
+MARIADB__USER=root
+MARIADB__PASSWORD=your_strong_password
+MARIADB__HOST=localhost
+MARIADB__PORT=3306
+
+# Storage Configuration
+STORAGE__URL=s3://your-bucket/backups?endpoint=https://s3.endpoint
+
+# S3 Configuration (when using S3 storage)
+AWS_ACCESS_KEY=your_access_key
+AWS_SECRET_KEY=your_secret_key
+AWS_REGION=us-east-1
+
+# Backup Settings
+BACKUP__LIMITS__MAX_COUNT=30  # Keep last 30 backups
+```
+
+### Backup Script Options
+
+The `backup.sh` script can be customized:
+
+```bash
+# Path to the mariadb-backup-s3 binary
+BACKUP_BINARY="/usr/local/bin/mariadb-backup-s3"
+
+# Environment file path
+ENV_FILE="/path/to/backup.env"
+
+# Log file paths
+LOG_FILE="/var/log/mariadb-backup.log"
+ERROR_LOG="/var/log/mariadb-backup-error.log"
+
+# Email for notifications (optional)
+NOTIFY_EMAIL="admin@example.com"
+```
+
+## 🔍 Troubleshooting
+
+### Check CRON Service Status
+
+```bash
+# Systemd-based systems
+sudo systemctl status cron
+
+# SysV-init systems
+sudo service cron status
+```
+
+### Check CRON Logs
+
+```bash
+# Systemd journal
+sudo journalctl -u cron -f
+
+# Traditional syslog
+tail -f /var/log/syslog | grep CRON
+```
+
+### Test Backup Script Manually
+
+```bash
+# Run the backup script manually to test
+./backup.sh
+
+# Check exit code
+echo $?
+```
+
+### Check Backup Logs
+
+```bash
+# View main log
+tail -f /var/log/mariadb-backup.log
+
+# View error log
+tail -f /var/log/mariadb-backup-error.log
+```
+
+## 📋 Best Practices
+
+1. **Backup Retention**: Configure `BACKUP__LIMITS__MAX_COUNT` to keep an appropriate number of backups
+2. **Monitoring**: Set up log monitoring to alert on backup failures
+3. **Testing**: Regularly test backup restoration process
+4. **Security**: Restrict access to backup files and environment variables
+5. **Documentation**: Document your backup and restore procedures
+
+## 🔄 Rotation and Cleanup
+
+The mariadb-backup-s3 tool automatically handles backup rotation based on the `BACKUP__LIMITS__MAX_COUNT` setting. Older backups are automatically removed when this limit is exceeded.
+
+## 📊 Monitoring
+
+Consider setting up monitoring for your backups:
+
+```bash
+# Add to crontab to check if backup ran successfully in the last 24 hours
+30 8 * * * if [ -f "/var/log/mariadb-backup.log" ] && [ $(find /var/log/mariadb-backup.log -mtime -1 | wc -l) -eq 0 ]; then echo "Backup may have failed" | mail -s "Backup Alert" admin@example.com; fi

--- a/examples/advanced-cron-backup/backup.env.example
+++ b/examples/advanced-cron-backup/backup.env.example
@@ -1,0 +1,67 @@
+# MariaDB Backup Environment Variables
+# Copy this file to backup.env and customize with your settings
+
+# =============================================================================
+# MariaDB Configuration
+# =============================================================================
+
+# Database connection settings
+MARIADB__USER=root
+MARIADB__PASSWORD=your_strong_password_here
+MARIADB__HOST=localhost
+MARIADB__PORT=3306
+
+# Optional: Additional mariabackup options
+# Example: MARIADB__BACKUP_OPTIONS="--skip-ssl --parallel=4"
+# MARIADB__BACKUP_OPTIONS=
+
+# =============================================================================
+# Storage Configuration
+# =============================================================================
+
+# Choose ONE of the following storage options:
+
+# Option 1: S3-compatible storage (AWS S3, MinIO, DigitalOcean Spaces, etc.)
+# Format: s3://bucket-name/path?endpoint=https://s3.example.com
+STORAGE__URL=s3://your-bucket-name/backups?endpoint=https://s3.amazonaws.com
+
+# Option 2: Local filesystem storage
+# Format: file:///absolute/path/to/backup/directory
+# STORAGE__URL=file:///var/backups/mariadb
+
+# =============================================================================
+# S3 Configuration (Required only when using S3 storage)
+# =============================================================================
+
+AWS_ACCESS_KEY=your_aws_access_key_here
+AWS_SECRET_KEY=your_aws_secret_key_here
+AWS_REGION=us-east-1
+
+# =============================================================================
+# Backup Settings
+# =============================================================================
+
+# Maximum number of backups to retain (older backups are automatically removed)
+BACKUP__LIMITS__MAX_COUNT=30
+
+# =============================================================================
+# Script Configuration (for backup.sh)
+# =============================================================================
+
+# Path to the mariadb-backup-s3 binary (adjust if needed)
+# BACKUP_BINARY=/usr/local/bin/mariadb-backup-s3
+
+# Log file paths (adjust if needed)
+# LOG_FILE=/var/log/mariadb-backup.log
+# ERROR_LOG=/var/log/mariadb-backup-error.log
+
+# Email address for failure notifications (optional, requires mail setup)
+# NOTIFY_EMAIL=admin@example.com
+
+# =============================================================================
+# Notes:
+# 1. Quote values that contain spaces (e.g., option lists); otherwise unquoted is fine.
+# 2. Keep this file secure as it contains sensitive credentials
+# 3. Test your configuration by running the backup script manually
+# 4. Adjust backup retention based on your storage capacity and compliance needs
+# =============================================================================

--- a/examples/advanced-cron-backup/backup.sh
+++ b/examples/advanced-cron-backup/backup.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# MariaDB Backup Script for CRON
+# This script wraps the mariadb-backup-s3 tool for use with system CRON
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${ENV_FILE:-$SCRIPT_DIR/backup.env}"
+
+# Check if environment file exists
+if [ ! -f "$ENV_FILE" ]; then
+    ts="$(date '+%Y-%m-%d %H:%M:%S')"
+    msg="Environment file not found: $ENV_FILE"
+    printf '[%s] ERROR: %s\n' "$ts" "$msg" >&2
+    exit 1
+fi
+
+# Export all variables
+set -a
+source "$ENV_FILE"
+set +a
+
+# Configuration - Adjust these paths as needed
+BACKUP_BINARY="${BACKUP_BINARY:-/usr/local/bin/mariadb-backup-s3}"
+LOG_FILE="${LOG_FILE:-/var/log/mariadb-backup.log}"
+ERROR_LOG="${ERROR_LOG:-/var/log/mariadb-backup-error.log}"
+NOTIFY_EMAIL="${NOTIFY_EMAIL:-}"
+
+# Ensure log directory exists
+mkdir -p "$(dirname "$LOG_FILE")"
+mkdir -p "$(dirname "$ERROR_LOG")"
+
+# Logging function
+log() {
+    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" >> "$LOG_FILE"
+}
+
+# Error logging function
+error_log() {
+    printf '[%s] ERROR: %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" >> "$ERROR_LOG"
+    printf '[%s] ERROR: %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" >> "$LOG_FILE"
+}
+
+# Email notification function
+send_notification() {
+    if [ -n "$NOTIFY_EMAIL" ]; then
+        local subject="MariaDB Backup Failed - $(hostname)"
+        local message="MariaDB backup failed on $(hostname) at $(date).
+
+Error: $1
+
+Check the logs for more details:
+- Main log: $LOG_FILE
+- Error log: $ERROR_LOG"
+
+        echo "$message" | mail -s "$subject" "$NOTIFY_EMAIL" || error_log "Failed to send notification email"
+    fi
+}
+
+# Check if backup binary exists
+if [ ! -f "$BACKUP_BINARY" ]; then
+    error_log "Backup binary not found: $BACKUP_BINARY"
+    send_notification "Backup binary not found: $BACKUP_BINARY"
+    exit 1
+fi
+
+# Check if backup binary is executable
+if [ ! -x "$BACKUP_BINARY" ]; then
+    error_log "Backup binary is not executable: $BACKUP_BINARY"
+    send_notification "Backup binary is not executable: $BACKUP_BINARY"
+    exit 1
+fi
+
+# Log backup start
+log "Starting MariaDB backup"
+
+# Run the backup with environment variables
+set +euo pipefail  # Temporarily disable for the backup command
+if output=$("$BACKUP_BINARY" 2>&1); then
+    set -euo pipefail
+    log "Backup completed successfully"
+    log "Output: $output"
+    exit 0
+else
+    exit_code=$?
+    set -euo pipefail
+    error_log "Backup failed with exit code $exit_code"
+    error_log "Output: $output"
+    send_notification "Backup failed with exit code $exit_code. Check logs for details."
+    exit $exit_code
+fi

--- a/examples/advanced-cron-backup/crontab.example
+++ b/examples/advanced-cron-backup/crontab.example
@@ -1,0 +1,52 @@
+# MariaDB Backup CRON Configuration
+# Copy this file and customize as needed, then install with:
+# crontab /path/to/this/file
+
+# Environment variables for CRON
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+MAILTO=""
+
+# =============================================================================
+# MariaDB Backup Schedules
+# Uncomment and adjust ONE of the following schedules based on your needs
+# =============================================================================
+
+# Option 1: Daily backup at 2 AM (recommended for most use cases)
+# 0 2 * * * /path/to/mariadb-backup-s3/examples/advanced-cron-backup/backup.sh
+
+# Option 2: Weekly backup on Sunday at 3 AM
+# 0 3 * * 0 /path/to/mariadb-backup-s3/examples/advanced-cron-backup/backup.sh
+
+# Option 3: Monthly backup on the 1st at 4 AM
+# 0 4 1 * * /path/to/mariadb-backup-s3/examples/advanced-cron-backup/backup.sh
+
+# Option 4: Every 6 hours (for high-availability systems)
+# 0 */6 * * * /path/to/mariadb-backup-s3/examples/advanced-cron-backup/backup.sh
+
+# Option 5: Twice daily at noon and midnight
+# 0 0,12 * * * /path/to/mariadb-backup-s3/examples/advanced-cron-backup/backup.sh
+
+# =============================================================================
+# Optional: Backup Monitoring and Maintenance Tasks
+# =============================================================================
+
+# Check if backup ran successfully in the last 24 hours (runs at 8 AM)
+# This sends an email if the backup log hasn't been updated in the last day
+# 30 8 * * * if [ -f "/var/log/mariadb-backup.log" ] && [ $(find /var/log/mariadb-backup.log -mtime -1 | wc -l) -eq 0 ]; then echo "Backup may have failed - no log entry in the last 24 hours" | mail -s "Backup Alert - $(hostname)" admin@example.com; fi
+
+# Rotate backup logs weekly (keeps 4 weeks of logs)
+# 0 3 * * 0 find /var/log/mariadb-backup*.log -mtime +28 -exec rm {} \;
+
+# Clean up old temporary backup files daily (if any)
+# 15 2 * * * find /tmp -name "mariadb-backup-*" -type d -mtime +1 -exec rm -rf {} \; 2>/dev/null || true
+
+# =============================================================================
+# Notes:
+# 1. Replace /path/to/mariadb-backup-s3 with the actual path to your installation
+# 2. Ensure the backup.sh script is executable: chmod +x backup.sh
+# 3. Configure backup.env with your database and storage settings
+# 4. Test the backup script manually before adding to CRON: ./backup.sh
+# 5. Check CRON logs: tail -f /var/log/syslog | grep CRON
+# 6. Check backup logs: tail -f /var/log/mariadb-backup.log
+# =============================================================================

--- a/examples/docker-cron-backup/README.md
+++ b/examples/docker-cron-backup/README.md
@@ -1,0 +1,32 @@
+# Docker Swarm CRON Backup Example 📋
+
+This example demonstrates how to set up automated MariaDB backups using a Docker Swarm cron job with the mariadb-backup-s3 tool. Uses swarm-cronjob mechanism for scheduling via Docker service labels.
+
+## 📋 Purpose
+This example shows how to automate MariaDB backups using Docker Swarm. It uses the mariadb-backup-s3 tool for backups and swarm-cronjob for scheduling. The backup process is automated and reliable.
+
+## ⚙️ Prerequisites
+* Docker Swarm setup
+
+## ⚙️ Environment Setup
+Create a `.env` file with:
+```
+AWS_REGION=your-region
+AWS_ACCESS_KEY_ID=your-access-key
+AWS_SECRET_ACCESS_KEY=your-secret-key
+MARIADB_ROOT_PASSWORD=your-db-password
+DB_BACKUP__OPTIONS="--skip-ssl"
+DB_BACKUP__SCHEDULE="0 2 * * *"
+TIMEZONE="America/New_York"
+```
+
+## 🚀 Installation
+You can deploy this example using either `docker stack deploy` or `docker service create`.
+
+### Using docker stack deploy
+```bash
+docker stack deploy -c examples/docker-cron-backup/compose.yml mariadb-backup
+```
+
+## 🔍 Verification
+To verify backups and view logs: check service logs for `db-backup` (Logs reference service name `mariadb-backup-s3` but the container runs as `db-backup`) and verify backup files in your S3 bucket.

--- a/examples/simple-cron-backup/.env.example
+++ b/examples/simple-cron-backup/.env.example
@@ -1,0 +1,1 @@
+../../.env.example

--- a/examples/simple-cron-backup/README.md
+++ b/examples/simple-cron-backup/README.md
@@ -1,0 +1,51 @@
+# CRON Backup Example (Minimal)
+
+This example demonstrates a minimal setup for automated MariaDB backups using system CRON with the mariadb-backup-s3 tool.
+
+## 📁 Files Structure
+
+```
+examples/simple-cron-backup/
+├── README.md
+├── .env.example
+└── crontab.example
+```
+
+## 🚀 Setup Instructions
+
+### 1. Create a Dedicated User
+
+Create a system user for backups:
+
+```bash
+sudo adduser --system --group --home /var/backups backup
+```
+
+### 2. Configure Environment
+
+Copy the environment template to the backup user’s home directory:
+
+```bash
+sudo install -m 600 -o backup -g backup .env.example /var/backups/.env
+sudo nano /var/backups/.env
+```
+
+### 3. Install CRON Job
+
+Add the CRON job:
+
+```bash
+sudo -u backup crontab -e
+```
+
+Insert the line from `crontab.example`:
+
+```
+0 2 * * * mariadb-backup-s3
+```
+
+## 📋 Best Practices
+
+- Keep your `.env` file secure with proper permissions (e.g., chmod 600)
+- Test the backup command manually before relying on CRON
+- Monitor backup logs for failures

--- a/examples/simple-cron-backup/crontab.example
+++ b/examples/simple-cron-backup/crontab.example
@@ -1,0 +1,6 @@
+# MariaDB Backup CRON Configuration
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/bin
+
+# Daily backup at 2 AM
+0 2 * * * /usr/local/bin/mariadb-backup-s3 >> "$HOME/mariadb-backup.log" 2>&1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added minimal, advanced, and Docker-Swarm CRON backup examples with cron-friendly script, env templates, sample schedules, logging, rotation, and optional email failure notifications.

* **Documentation**
  * Restructured Scheduling to surface four direct example links and removed old descriptive subsections.
  * Updated main env template to MariaDB-focused settings and changed default backup retention to 0 (unlimited).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->