### PR TITLE
[landing] fix permissions in systemd example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,7 @@ MARIADB__PASSWORD=secure_password
 # MariaDB Backup Options
 # Purpose: Additional options for the mariabackup command
 # Format: string
-# Example: "--parallel=4"
+# Example: "--skip-ssl --parallel=4"
 MARIADB__BACKUP_OPTIONS=
 
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The backup process follows these steps:
 
 - Go 1.23+ (for building from source)
 - MariaDB server
+- At least 2x the actual database size in free space (for successful backup)
 - Storage backend credentials (depending on chosen storage type)
 
 ## 📦 Installation

--- a/examples/advanced-cron-backup/README.md
+++ b/examples/advanced-cron-backup/README.md
@@ -12,6 +12,12 @@ examples/cron-backup/
 └── backup.env.example    # Environment variables template
 ```
 
+## 📋 Prerequisites
+
+To ensure successful backups:
+
+- At least 2x the actual database size in free space available
+
 ## 🚀 Setup Instructions
 
 ### 1. Create Environment File

--- a/examples/docker-cron-backup/README.md
+++ b/examples/docker-cron-backup/README.md
@@ -7,6 +7,7 @@ This example shows how to automate MariaDB backups using Docker Swarm. It uses t
 
 ## ⚙️ Prerequisites
 * Docker Swarm setup
+* At least 2x the actual database size in free space for successful backup
 
 ## ⚙️ Environment Setup
 Create a `.env` file with:

--- a/examples/simple-cron-backup/README.md
+++ b/examples/simple-cron-backup/README.md
@@ -11,6 +11,12 @@ examples/simple-cron-backup/
 └── crontab.example
 ```
 
+## 📋 Prerequisites
+
+To ensure successful backups:
+
+- At least 2x the actual database size in free space available
+
 ## 🚀 Setup Instructions
 
 ### 1. Create a Dedicated User

--- a/examples/systemd-service/README.md
+++ b/examples/systemd-service/README.md
@@ -25,7 +25,7 @@ MARIADB__HOST=localhost
 MARIADB__PORT=3306
 MARIADB__USER=backup
 MARIADB__PASSWORD=your_secure_password
-MARIADB__BACKUP_OPTIONS=--all-databases
+MARIADB__BACKUP_OPTIONS=--skip-ssl --parallel=4
 
 # Storage configuration (S3)
 STORAGE__URL=s3://your-bucket-name/backup-path?endpoint=https://s3.example.com
@@ -48,7 +48,6 @@ Create a dedicated user for backups:
 
 ```bash
 sudo useradd -r -s /usr/sbin/nologin backup-user
-sudo usermod -aG mysql backup-user
 sudo mkdir -p /var/backups/mariadb
 sudo chown backup-user:backup-user /var/backups/mariadb
 ```

--- a/landing/index.html
+++ b/landing/index.html
@@ -281,6 +281,7 @@ sudo install -m 0755 mariadb-backup-s3 /usr/local/bin/
 
 # Create backup user
 sudo useradd -r -s /usr/sbin/nologin backup-user
+sudo usermod -aG mysql backup-user
 sudo mkdir -p /var/backups/mariadb
 sudo chown backup-user:backup-user /var/backups/mariadb
 

--- a/landing/index.html
+++ b/landing/index.html
@@ -233,7 +233,7 @@ services:
       - MARIADB__HOST=db
       - MARIADB__USER=root
       - MARIADB__PASSWORD=your-db-password
-      - MARIADB__BACKUP_OPTIONS=--skip-ssl
+      - MARIADB__BACKUP_OPTIONS=--skip-ssl --parallel=4
       - STORAGE__URL=s3://your-bucket/backups
       - AWS_ACCESS_KEY_ID=your-access-key
       - AWS_SECRET_ACCESS_KEY=your-secret-key
@@ -281,7 +281,6 @@ sudo install -m 0755 mariadb-backup-s3 /usr/local/bin/
 
 # Create backup user
 sudo useradd -r -s /usr/sbin/nologin backup-user
-sudo usermod -aG mysql backup-user
 sudo mkdir -p /var/backups/mariadb
 sudo chown backup-user:backup-user /var/backups/mariadb
 
@@ -290,7 +289,7 @@ sudo tee /etc/default/mariadb-backup-s3 > /dev/null << EOF
 MARIADB__HOST=localhost
 MARIADB__USER=backup_user
 MARIADB__PASSWORD=secure_password
-MARIADB__BACKUP_OPTIONS=--skip-ssl
+MARIADB__BACKUP_OPTIONS=--skip-ssl --parallel=4
 STORAGE__URL=s3://your-bucket/backups
 AWS_ACCESS_KEY_ID=your-access-key
 AWS_SECRET_ACCESS_KEY=your-secret-key
@@ -311,6 +310,8 @@ EnvironmentFile=/etc/default/mariadb-backup-s3
 ExecStart=/usr/local/bin/mariadb-backup-s3
 User=backup-user
 Group=backup-user
+SupplementaryGroups=mysql
+UMask=0077
 TimeoutStartSec=2h
 
 # Security hardening


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Backup service now runs with the database group and a stricter file-creation mask to reduce residual file access.
  - Backup operations enabled for parallel execution (4 threads) for faster backups.
- Documentation
  - Removed the manual instruction to add the backup user to the database group.
  - Updated examples and README files to show parallel backups and a new prerequisite requiring at least 2× the database size in free disk space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->