### PR TITLE
[docs] add S3 query params to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,13 +168,17 @@ Override any configuration with flags:
 For S3-compatible storage (including AWS S3, MinIO, DigitalOcean Spaces, etc.):
 
 ```dotenv
-STORAGE__URL=s3://bucket-name/path?endpoint=https://s3.example.com&region=us-east-1
+STORAGE__URL=s3://bucket-name/path?endpoint=https://s3.example.com
 ```
 
 **Required for S3:**
 - `AWS_ACCESS_KEY`: Your access key
 - `AWS_SECRET_KEY`: Your secret key
 - `AWS_REGION`: AWS region (or any region for non-AWS S3)
+
+**Query Parameters:**
+- `endpoint`: S3 endpoint URL
+- `s3-force-path-style`: Set to "true" to use path-style URLs
 
 ### FTP Storage
 For FTP servers:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated S3 Storage section: clarified STORAGE__URL example by removing the region query parameter.
  * Added a “Query Parameters” subsection outlining supported options (endpoint, s3-force-path-style) and how to configure them.
  * Improved guidance for formatting S3 endpoints and enabling path-style access.
  * No functional changes; documentation only, to help users correctly format URLs and understand configurable parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->