### PR TITLE
[logging] use lowercase values for level and format env vars

### DIFF
--- a/internal/logging/config.go
+++ b/internal/logging/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 )
 
 type Format string
@@ -29,7 +30,7 @@ func DefaultConfig() Config {
 	enableColors := true
 	timeFormat := "2006-01-02 15:04:05.000"
 
-	switch os.Getenv("LOG_LEVEL") {
+	switch strings.ToLower(os.Getenv("LOG_LEVEL")) {
 	case "debug":
 		level = LogLevelDebug
 	case "info":
@@ -42,7 +43,7 @@ func DefaultConfig() Config {
 		level = LogLevelFatal
 	}
 
-	if os.Getenv("LOG_FORMAT") == "json" {
+	if strings.ToLower(os.Getenv("LOG_FORMAT")) == "json" {
 		format = FormatJSON
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Logging configuration environment variables are now case-insensitive, allowing values like "JSON", "Json", and "json" to be processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->