### PR TITLE
[retention] implement module with registry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   - [✨ Features](#-features)
   - [🛠️ How It Works](#️-how-it-works)
     - [Temporary Working Directory](#temporary-working-directory)
+    - [Backup Registry](#backup-registry)
   - [📋 Prerequisites](#-prerequisites)
   - [📦 Installation](#-installation)
     - [Binary Installation (Recommended)](#binary-installation-recommended)
@@ -23,6 +24,8 @@
   - [🚀 Usage](#-usage)
     - [Backup](#backup)
     - [Restore](#restore)
+    - [Retention](#retention)
+    - [Registry](#registry)
   - [📂 Storage Types](#-storage-types)
     - [S3 Storage](#s3-storage)
     - [FTP Storage](#ftp-storage)
@@ -62,7 +65,8 @@ nano .env  # Edit with your credentials
 - 🔑 Optional encryption using AES-256-GCM
 - ☁️ Multiple storage backends (S3-compatible, FTP, filesystem)
 - 🔌 Pluggable storage interface for extensibility
-- 🔄 Automatic backup rotation
+- 🔄 Automatic backup rotation with configurable retention policies
+- 📋 Backup registry for tracking and managing backups
 - 🐳 Docker container support
 
 ## 🛠️ How It Works
@@ -75,7 +79,8 @@ The backup process follows these steps:
 4. 🗜️ Compress backup to `.tar.gz` archive
 5. 🔑 Encrypt archive using AES-256-GCM
 6. 🚀 Upload archive to configured storage backend
-7. 🧹 Clean up old backups based on retention policy
+7. 📋 Update backup registry with new backup metadata
+8. 🧹 Clean up old backups based on retention policy (unless `--skip-retention` is set)
 
 The restore process follows these steps:
 
@@ -92,6 +97,28 @@ The tool uses a temporary working directory to store intermediate files. By defa
 export TMPDIR=/mnt/data/backup
 ./mariadb-backup-s3 backup
 ```
+
+### Backup Registry
+
+The tool maintains a backup registry (`.backup-registry.json`) in the storage backend to track all backups. This registry enables:
+
+- **Backup tracking**: Each backup is recorded with metadata including ID, filename, creation time, size, SHA256 hash, encryption status, and tool version
+- **Retention management**: The registry is used to apply retention policies and clean up old backups
+- **Backup listing**: View all available backups with their status and metadata
+
+The registry is automatically updated when backups are created or deleted. Each backup entry includes:
+
+| Field        | Description                                   |
+| ------------ | --------------------------------------------- |
+| `id`         | Unique identifier (timestamp + SHA256 prefix) |
+| `filename`   | Backup filename                               |
+| `created_at` | Creation timestamp                            |
+| `size_bytes` | File size in bytes                            |
+| `sha256`     | SHA256 hash of the backup file                |
+| `status`     | Status: `ready`, `failed`, or `deleted`       |
+| `encrypted`  | Whether the backup is encrypted               |
+| `encryption` | Encryption metadata (algorithm)               |
+| `tool`       | Tool name and version                         |
 
 ## 📋 Prerequisites
 
@@ -161,10 +188,12 @@ mariadb-backup-s3 [global options] command [command options] [arguments...]
 
 The tool offers the following commands:
 
-| Command   | Description                                       |
-| --------- | ------------------------------------------------- |
-| `backup`  | Perform a backup of the MariaDB database          |
-| `restore` | Restore the database files to specified directory |
+| Command     | Description                                       |
+| ----------- | ------------------------------------------------- |
+| `backup`    | Perform a backup of the MariaDB database          |
+| `restore`   | Restore the database files to specified directory |
+| `retention` | Apply retention policies to backups               |
+| `registry`  | Manage backup registry                            |
 
 ### Backup
 
@@ -174,22 +203,27 @@ mariadb-backup-s3 backup [options]
 
 **Options:**
 
-| Option                        | Env Var                     | Description                                      | Default value    |
-| ----------------------------- | --------------------------- | ------------------------------------------------ | ---------------- |
-| **Database**                  |                             |                                                  |                  |
-| `--db-host`, `--host`         | `MARIADB__HOST`             | MariaDB hostname                                 | `localhost`      |
-| `--db-port`, `--port`         | `MARIADB__PORT`             | MariaDB port                                     | `3306`           |
-| `--db-user`, `--user`         | `MARIADB__USER`             | MariaDB username                                 | `root`           |
-| `--db-password`, `--password` | `MARIADB__PASSWORD`         | MariaDB password                                 | `""`             |
-| **Storage**                   |                             |                                                  |                  |
-| `--storage`, `--storage-url`  | `STORAGE__URL`              | Storage URL, see [Storage Types](#storage-types) | **required**     |
-| **Encryption**                |                             |                                                  |                  |
-| `--encryption-key`            | `ENCRYPTION__KEY`           | Encryption key                                   | `""`             |
-| **mariadb-backup**            |                             |                                                  |                  |
-| `--db-backup-binary`          | `MARIADB__BACKUP_BINARY`    | MariaDB backup binary path                       | `mariadb-backup` |
-| `--db-backup-options`         | `MARIADB__BACKUP_OPTIONS`   | MariaDB backup options                           | `""`             |
-| **Retention**                 |                             |                                                  |                  |
-| `--backup-limits-max-count`   | `BACKUP__LIMITS__MAX_COUNT` | Number of backups to keep, 0 = unlimited         | `0`              |
+| Option                        | Env Var                   | Description                                       | Default value    |
+| ----------------------------- | ------------------------- | ------------------------------------------------- | ---------------- |
+| **Database**                  |                           |                                                   |                  |
+| `--db-host`, `--host`         | `MARIADB__HOST`           | MariaDB hostname                                  | `localhost`      |
+| `--db-port`, `--port`         | `MARIADB__PORT`           | MariaDB port                                      | `3306`           |
+| `--db-user`, `--user`         | `MARIADB__USER`           | MariaDB username                                  | `root`           |
+| `--db-password`, `--password` | `MARIADB__PASSWORD`       | MariaDB password                                  | `""`             |
+| **Storage**                   |                           |                                                   |                  |
+| `--storage`, `--storage-url`  | `STORAGE__URL`            | Storage URL, see [Storage Types](#-storage-types) | **required**     |
+| **Encryption**                |                           |                                                   |                  |
+| `--encryption-key`            | `ENCRYPTION__KEY`         | Encryption key                                    | `""`             |
+| **mariadb-backup**            |                           |                                                   |                  |
+| `--db-backup-binary`          | `MARIADB__BACKUP_BINARY`  | MariaDB backup binary path                        | `mariadb-backup` |
+| `--db-backup-options`         | `MARIADB__BACKUP_OPTIONS` | MariaDB backup options                            | `""`             |
+| **Retention**                 |                           |                                                   |                  |
+| `--retention-count`           | `RETENTION__COUNT`        | Number of backups to retain, 0 = unlimited        | `0`              |
+| `--max-age`                   | `RETENTION__MAX_AGE`      | Maximum age of backups to keep (e.g. 24h, 168h)   | unlimited        |
+| `--keep-daily`                | `RETENTION__KEEP_DAILY`   | Number of daily backups to keep                   | unlimited        |
+| `--keep-weekly`               | `RETENTION__KEEP_WEEKLY`  | Number of weekly backups to keep                  | unlimited        |
+| `--keep-monthly`              | `RETENTION__KEEP_MONTHLY` | Number of monthly backups to keep                 | unlimited        |
+| `--skip-retention`            | `BACKUP__SKIP_RETENTION`  | Skip retention policy after backup                | `false`          |
 
 **Example:**
 
@@ -203,19 +237,24 @@ mariadb-backup-s3 backup [options]
 ### Restore
 
 ```bash
-mariadb-backup-s3 restore [options] filename
+mariadb-backup-s3 restore [options] [backup_name.tar.gz | --latest | --backup-id=<id>]
 ```
 
 **Options:**
 
-| Option                       | Env Var               | Description                                      | Default value |
-| ---------------------------- | --------------------- | ------------------------------------------------ | ------------- |
-| **Storage**                  |                       |                                                  |               |
-| `--storage`, `--storage-url` | `STORAGE__URL`        | Storage URL, see [Storage Types](#storage-types) | **required**  |
-| **Encryption**               |                       |                                                  |               |
-| `--encryption-key`           | `ENCRYPTION__KEY`     | Encryption key                                   | `""`          |
-| **Restore**                  |                       |                                                  |               |
-| `--target-dir`               | `RESTORE__TARGET_DIR` | Target directory to restore files to             | **required**  |
+| Option                       | Env Var               | Description                                       | Default value |
+| ---------------------------- | --------------------- | ------------------------------------------------- | ------------- |
+| **Storage**                  |                       |                                                   |               |
+| `--storage`, `--storage-url` | `STORAGE__URL`        | Storage URL, see [Storage Types](#-storage-types) | **required**  |
+| **Encryption**               |                       |                                                   |               |
+| `--encryption-key`           | `ENCRYPTION__KEY`     | Encryption key                                    | `""`          |
+| **Restore**                  |                       |                                                   |               |
+| `--target-dir`               | `RESTORE__TARGET_DIR` | Target directory to restore files to              | **required**  |
+| `--latest`                   |                       | Restore latest ready backup from registry         | `false`       |
+| `--backup-id`                |                       | Restore backup by registry backup ID              | `""`          |
+
+> **Note**
+> Exactly one backup selector must be specified: either a filename argument, `--latest`, or `--backup-id`.
 
 **Arguments:**
 
@@ -232,6 +271,96 @@ mariadb-backup-s3 restore [options] filename
   backup_name.tar.gz
 ```
 
+### Retention
+
+The `retention` command applies retention policies to backups stored in the configured storage backend. This allows you to clean up old backups based on various criteria.
+
+```bash
+mariadb-backup-s3 retention [options]
+```
+
+**Options:**
+
+| Option              | Env Var                   | Description                                          | Default value |
+| ------------------- | ------------------------- | ---------------------------------------------------- | ------------- |
+| **Storage**         |                           |                                                      |               |
+| `--storage-url`     | `STORAGE__URL`            | Storage URL, see [Storage Types](#-storage-types)    | **required**  |
+| **Retention**       |                           |                                                      |               |
+| `--retention-count` | `RETENTION__COUNT`        | Number of backups to retain, 0 = unlimited           | `0`           |
+| `--max-age`         | `RETENTION__MAX_AGE`      | Maximum age of backups to keep (e.g. 24h, 168h)      | unlimited     |
+| `--keep-daily`      | `RETENTION__KEEP_DAILY`   | Number of daily backups to keep                      | unlimited     |
+| `--keep-weekly`     | `RETENTION__KEEP_WEEKLY`  | Number of weekly backups to keep                     | unlimited     |
+| `--keep-monthly`    | `RETENTION__KEEP_MONTHLY` | Number of monthly backups to keep                    | unlimited     |
+| **Options**         |                           |                                                      |               |
+| `--dry-run`         | `RETENTION__DRY_RUN`      | Show what would be deleted without actually deleting | `false`       |
+| `--force`           | `RETENTION__FORCE`        | Continue even if errors occur                        | `false`       |
+
+**Retention Policy Examples:**
+
+```shell
+# Keep only the 7 most recent backups
+./mariadb-backup-s3 retention \
+  --storage-url="s3://my-bucket/backups" \
+  --retention-count=7
+
+# Keep backups from the last 7 days
+./mariadb-backup-s3 retention \
+  --storage-url="s3://my-bucket/backups" \
+  --max-age=168h
+
+# Keep 1 daily backup for 7 days, 1 weekly for 4 weeks, 1 monthly for 12 months
+./mariadb-backup-s3 retention \
+  --storage-url="s3://my-bucket/backups" \
+  --keep-daily=7 \
+  --keep-weekly=4 \
+  --keep-monthly=12
+
+# Preview what would be deleted without actually deleting
+./mariadb-backup-s3 retention \
+  --storage-url="s3://my-bucket/backups" \
+  --retention-count=3 \
+  --dry-run
+```
+
+> **Note**
+> At least one retention policy must be enabled. The retention command will fail if no policies are specified.
+
+### Registry
+
+The `registry` command allows you to manage and view the backup registry.
+
+```bash
+mariadb-backup-s3 registry [command] [options]
+```
+
+**Subcommands:**
+
+| Command | Alias | Description                |
+| ------- | ----- | -------------------------- |
+| `list`  | `ls`  | List backups from registry |
+
+**List Command Options:**
+
+| Option          | Env Var        | Description                                       | Default value |
+| --------------- | -------------- | ------------------------------------------------- | ------------- |
+| `--storage-url` | `STORAGE__URL` | Storage URL, see [Storage Types](#-storage-types) | **required**  |
+
+**Example:**
+
+```shell
+./mariadb-backup-s3 registry list \
+  --storage-url="s3://my-bucket/backups"
+```
+
+**Output:**
+
+The list command displays all backups in the registry with the following information:
+- **ID**: Unique backup identifier
+- **Created At**: Backup creation timestamp
+- **Status**: Backup status (`ready`, `failed`, or `deleted`)
+- **Encrypted**: Whether the backup is encrypted
+- **Size**: Backup file size in bytes
+- **Filename**: Backup filename
 
 ## 📂 Storage Types
 

--- a/internal/backup/config.go
+++ b/internal/backup/config.go
@@ -9,18 +9,10 @@ import (
 
 var ErrValidationFailed = errors.New("validation failed")
 
-type LimitsConfig struct {
-	MaxCount int
-}
-
-type Backup struct {
-	Limits LimitsConfig
-}
-
 type Config struct {
+	Version    string
 	MariaDB    config.MariaDB
 	Storage    config.Storage
-	Backup     Backup
 	Encryption config.Encryption
 }
 
@@ -38,12 +30,10 @@ func (c Config) Validate() error {
 
 func DefaultConfig() Config {
 	return Config{
+		Version: "",
 		MariaDB: config.DefaultMariaDB(),
 		Storage: config.Storage{
 			URL: "",
-		},
-		Backup: Backup{
-			Limits: LimitsConfig{MaxCount: 0},
 		},
 		Encryption: config.Encryption{
 			EncryptionKey: "",

--- a/internal/backup/operation.go
+++ b/internal/backup/operation.go
@@ -3,6 +3,8 @@ package backup
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -14,19 +16,36 @@ import (
 
 	"github.com/capcom6/mariadb-backup-s3/internal/encryption"
 	"github.com/capcom6/mariadb-backup-s3/internal/logging"
+	"github.com/capcom6/mariadb-backup-s3/internal/registry"
 	"github.com/capcom6/mariadb-backup-s3/internal/sanitizer"
 	"github.com/capcom6/mariadb-backup-s3/internal/storage"
+	"github.com/capcom6/mariadb-backup-s3/pkg/counting"
 	"github.com/capcom6/mariadb-backup-s3/pkg/pipeline"
 )
 
 type Operation struct {
 	config Config
+
+	registrySvc *registry.Service
+
+	storage storage.Backend
+
 	logger logging.Logger
 }
 
-func NewOperation(config Config, logger logging.Logger) *Operation {
+func NewOperation(
+	config Config,
+	registrySvc *registry.Service,
+	storage storage.Backend,
+	logger logging.Logger,
+) *Operation {
 	return &Operation{
 		config: config,
+
+		registrySvc: registrySvc,
+
+		storage: storage,
+
 		logger: logger,
 	}
 }
@@ -83,13 +102,15 @@ func (o *Operation) Run(ctx context.Context) error {
 			return o.encrypt(ctx, r, w)
 		},
 		func(ctx context.Context, r io.Reader, _ io.Writer) error {
-			return o.upload(ctx, r, targetName)
+			return o.upload(ctx, r, targetName, start.UTC())
 		},
 	)
 
 	if err != nil {
 		return fmt.Errorf("failed to backup: %w", err)
 	}
+
+	//TODO: apply retention policy
 
 	return nil
 }
@@ -231,7 +252,7 @@ func (o *Operation) encrypt(ctx context.Context, r io.Reader, w io.Writer) error
 	return nil
 }
 
-func (o *Operation) upload(ctx context.Context, r io.Reader, targetName string) error {
+func (o *Operation) upload(ctx context.Context, r io.Reader, targetName string, createdAt time.Time) error {
 	o.logger.Info(ctx, "Stage 4: Upload")
 	start := time.Now()
 	defer func() {
@@ -241,37 +262,123 @@ func (o *Operation) upload(ctx context.Context, r io.Reader, targetName string) 
 		})
 	}()
 
-	u, err := o.config.Storage.GetURL()
-	if err != nil {
-		o.logger.Error(ctx, "Upload failed: failed to parse storage url", err, logging.Fields{
-			"filename": targetName,
-		})
-		return fmt.Errorf("failed to parse storage url: %w", err)
-	}
-
-	storageBackend, err := storage.New(u)
-	if err != nil {
-		o.logger.Error(ctx, "Upload failed: failed to create storage backend", err, logging.Fields{
-			"filename": targetName,
-		})
-		return fmt.Errorf("failed to create storage backend: %w", err)
-	}
+	shaSum := sha256.New()
+	counter := counting.NewWriter()
+	uploadReader := io.TeeReader(r, io.MultiWriter(shaSum, counter))
 
 	// Upload the backup
-	if uploadErr := storageBackend.Upload(ctx, targetName, r); uploadErr != nil {
+	if uploadErr := o.storage.Upload(ctx, targetName, uploadReader); uploadErr != nil {
 		o.logger.Error(ctx, "Upload failed", uploadErr, logging.Fields{
 			"filename": targetName,
 		})
 		return fmt.Errorf("failed to upload: %w", uploadErr)
 	}
 
-	// Cleanup old backups
-	if delErr := storageBackend.DeleteOldBackups(ctx, o.config.Backup.Limits.MaxCount); delErr != nil {
-		o.logger.Error(ctx, "failed to cleanup", delErr, logging.Fields{
-			"filename":  targetName,
-			"max_count": o.config.Backup.Limits.MaxCount,
+	entry := registry.NewBackupEntry(
+		targetName,
+		createdAt,
+		counter.N(),
+		hex.EncodeToString(shaSum.Sum(nil)),
+		registry.StatusReady,
+		o.config.Encryption.Enabled(),
+		nil,
+		&registry.ToolMetadata{
+			Name:    "mariadb-backup-s3",
+			Version: o.config.Version,
+		},
+	)
+
+	if o.config.Encryption.Enabled() {
+		entry.Encryption = &registry.EncryptionMetadata{Algorithm: "AES-256-GCM"}
+	}
+
+	if _, err := o.registrySvc.Append(ctx, entry); err != nil {
+		o.logger.Error(ctx, "registry append failed", err, logging.Fields{
+			"filename": targetName,
 		})
+		return fmt.Errorf("failed to append registry: %w", err)
 	}
 
 	return nil
 }
+
+// func applyRegistryRetention(ctx context.Context, storageBackend storage.Backend, maxCount int) error {
+// 	if maxCount == 0 {
+// 		return nil
+// 	}
+// 	if maxCount < 0 {
+// 		return fmt.Errorf("invalid maxCount: %d", maxCount)
+// 	}
+
+// 	reg, err := loadRegistryForRetention(ctx, storageBackend)
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	ready := make([]registry.BackupEntry, 0, len(reg.Backups))
+// 	for _, b := range reg.Backups {
+// 		if b.Status == registry.StatusReady {
+// 			ready = append(ready, b)
+// 		}
+// 	}
+
+// 	if len(ready) <= maxCount {
+// 		return nil
+// 	}
+
+// 	sort.Slice(ready, func(i, j int) bool {
+// 		return ready[i].CreatedAt.After(ready[j].CreatedAt)
+// 	})
+
+// 	keep := make(map[string]struct{}, maxCount)
+// 	for _, b := range ready[:maxCount] {
+// 		keep[b.Filename] = struct{}{}
+// 	}
+
+// 	retained := make([]registry.BackupEntry, 0, len(reg.Backups))
+// 	for _, b := range reg.Backups {
+// 		if b.Status != registry.StatusReady {
+// 			retained = append(retained, b)
+// 			continue
+// 		}
+
+// 		if _, ok := keep[b.Filename]; ok {
+// 			retained = append(retained, b)
+// 			continue
+// 		}
+
+// 		if err := storageBackend.Delete(ctx, b.Filename); err != nil && !errors.Is(err, storage.ErrNotFound) {
+// 			return fmt.Errorf("failed to delete old backup %s: %w", b.Filename, err)
+// 		}
+// 	}
+
+// 	reg.Backups = retained
+// 	reg.UpdatedAt = time.Now().UTC()
+
+// 	var out bytes.Buffer
+// 	if err := reg.Write(&out); err != nil {
+// 		return fmt.Errorf("failed to serialize registry after retention: %w", err)
+// 	}
+// 	if err := storageBackend.UploadBytes(ctx, registry.FileName, out.Bytes()); err != nil {
+// 		return fmt.Errorf("failed to persist registry after retention: %w", err)
+// 	}
+
+// 	return nil
+// }
+
+// func loadRegistryForRetention(ctx context.Context, storageBackend storage.Backend) (registry.Registry, error) {
+// 	data, err := storageBackend.DownloadBytes(ctx, registry.FileName)
+// 	if err != nil {
+// 		if errors.Is(err, storage.ErrNotFound) {
+// 			return rebuildRegistryFromListing(ctx, storageBackend)
+// 		}
+// 		return registry.Registry{}, fmt.Errorf("failed to read registry: %w", err)
+// 	}
+
+// 	reg, parseErr := registry.Parse(bytes.NewReader(data))
+// 	if parseErr != nil {
+// 		return rebuildRegistryFromListing(ctx, storageBackend)
+// 	}
+
+// 	return reg, nil
+// }

--- a/internal/backup/operation.go
+++ b/internal/backup/operation.go
@@ -110,8 +110,6 @@ func (o *Operation) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to backup: %w", err)
 	}
 
-	//TODO: apply retention policy
-
 	return nil
 }
 
@@ -301,84 +299,3 @@ func (o *Operation) upload(ctx context.Context, r io.Reader, targetName string, 
 
 	return nil
 }
-
-// func applyRegistryRetention(ctx context.Context, storageBackend storage.Backend, maxCount int) error {
-// 	if maxCount == 0 {
-// 		return nil
-// 	}
-// 	if maxCount < 0 {
-// 		return fmt.Errorf("invalid maxCount: %d", maxCount)
-// 	}
-
-// 	reg, err := loadRegistryForRetention(ctx, storageBackend)
-// 	if err != nil {
-// 		return err
-// 	}
-
-// 	ready := make([]registry.BackupEntry, 0, len(reg.Backups))
-// 	for _, b := range reg.Backups {
-// 		if b.Status == registry.StatusReady {
-// 			ready = append(ready, b)
-// 		}
-// 	}
-
-// 	if len(ready) <= maxCount {
-// 		return nil
-// 	}
-
-// 	sort.Slice(ready, func(i, j int) bool {
-// 		return ready[i].CreatedAt.After(ready[j].CreatedAt)
-// 	})
-
-// 	keep := make(map[string]struct{}, maxCount)
-// 	for _, b := range ready[:maxCount] {
-// 		keep[b.Filename] = struct{}{}
-// 	}
-
-// 	retained := make([]registry.BackupEntry, 0, len(reg.Backups))
-// 	for _, b := range reg.Backups {
-// 		if b.Status != registry.StatusReady {
-// 			retained = append(retained, b)
-// 			continue
-// 		}
-
-// 		if _, ok := keep[b.Filename]; ok {
-// 			retained = append(retained, b)
-// 			continue
-// 		}
-
-// 		if err := storageBackend.Delete(ctx, b.Filename); err != nil && !errors.Is(err, storage.ErrNotFound) {
-// 			return fmt.Errorf("failed to delete old backup %s: %w", b.Filename, err)
-// 		}
-// 	}
-
-// 	reg.Backups = retained
-// 	reg.UpdatedAt = time.Now().UTC()
-
-// 	var out bytes.Buffer
-// 	if err := reg.Write(&out); err != nil {
-// 		return fmt.Errorf("failed to serialize registry after retention: %w", err)
-// 	}
-// 	if err := storageBackend.UploadBytes(ctx, registry.FileName, out.Bytes()); err != nil {
-// 		return fmt.Errorf("failed to persist registry after retention: %w", err)
-// 	}
-
-// 	return nil
-// }
-
-// func loadRegistryForRetention(ctx context.Context, storageBackend storage.Backend) (registry.Registry, error) {
-// 	data, err := storageBackend.DownloadBytes(ctx, registry.FileName)
-// 	if err != nil {
-// 		if errors.Is(err, storage.ErrNotFound) {
-// 			return rebuildRegistryFromListing(ctx, storageBackend)
-// 		}
-// 		return registry.Registry{}, fmt.Errorf("failed to read registry: %w", err)
-// 	}
-
-// 	reg, parseErr := registry.Parse(bytes.NewReader(data))
-// 	if parseErr != nil {
-// 		return rebuildRegistryFromListing(ctx, storageBackend)
-// 	}
-
-// 	return reg, nil
-// }

--- a/internal/cli/commands/backup/backup.go
+++ b/internal/cli/commands/backup/backup.go
@@ -8,6 +8,7 @@ import (
 	"github.com/capcom6/mariadb-backup-s3/internal/core/codes"
 	"github.com/capcom6/mariadb-backup-s3/internal/logging"
 	"github.com/capcom6/mariadb-backup-s3/internal/registry"
+	"github.com/capcom6/mariadb-backup-s3/internal/retention"
 	"github.com/capcom6/mariadb-backup-s3/internal/storage"
 	"github.com/capcom6/mariadb-backup-s3/pkg/cliutil"
 	"github.com/urfave/cli/v3"
@@ -33,6 +34,12 @@ func Command() *cli.Command {
 				cliutil.DefaultValue("mariadb-backup"),
 			),
 		},
+
+		&cli.BoolFlag{
+			Name:    "skip-retention",
+			Usage:   "skip retention policy",
+			Sources: cli.EnvVars("BACKUP__SKIP_RETENTION"),
+		},
 	)
 
 	return &cli.Command{
@@ -43,75 +50,98 @@ func Command() *cli.Command {
 		Commands: []*cli.Command{
 			ListCommand(),
 		},
-		Action: func(ctx context.Context, cmd *cli.Command) error {
-			logger := logging.GetLogger(ctx)
-			if logger == nil {
-				return cli.Exit("failed to retrieve logger", codes.InternalError)
-			}
-
-			operationID := logging.GenerateOperationID("backup")
-			logger = logger.WithContext("backup-cmd", operationID)
-
-			logger.Info(ctx, "Backup command initiated")
-
-			// Log command parameters for debugging
-			logger.Debug(ctx, "Parsing command parameters", logging.Fields{
-				"db_host":           cmd.String("db-host"),
-				"db_port":           cmd.Int("db-port"),
-				"db_user":           cmd.String("db-user"),
-				"db_password":       "***", // Don't log actual password
-				"db_backup_options": cmd.String("db-backup-options"),
-				"db_backup_binary":  cmd.String("db-backup-binary"),
-				"storage_url":       cmd.String("storage-url"),
-				"encryption_key":    "***", // Don't log actual key
-			})
-
-			cfg, err := parseConfig(cmd)
-			if err != nil {
-				logger.Error(ctx, "Failed to parse configuration", err)
-				return cli.Exit("backup command failed", codes.ParamsError)
-			}
-
-			logger.Debug(ctx, "Configuration validated successfully", logging.Fields{
-				"db_host":            cfg.MariaDB.Host,
-				"db_port":            cfg.MariaDB.Port,
-				"db_user":            cfg.MariaDB.User,
-				"storage_url":        cfg.Storage.URL,
-				"encryption_enabled": cfg.Encryption.Enabled(),
-			})
-
-			u, err := cfg.Storage.GetURL()
-			if err != nil {
-				logger.Error(ctx, "Failed to parse storage url", err)
-				return cli.Exit("backup command failed", codes.ParamsError)
-			}
-
-			storageSvc, err := storage.New(u)
-			if err != nil {
-				logger.Error(ctx, "Failed to initialize storage backend", err)
-				return cli.Exit("backup command failed", codes.InternalError)
-			}
-			defer func() {
-				if closeErr := storageSvc.Close(); closeErr != nil {
-					logger.Error(ctx, "Failed to close storage backend", closeErr)
-				}
-			}()
-
-			registrySvc := registry.NewService(storageSvc)
-
-			logger.Info(ctx, "Starting backup execution", logging.Fields{
-				"db_host":            cfg.MariaDB.Host,
-				"db_port":            cfg.MariaDB.Port,
-				"encryption_enabled": cfg.Encryption.Enabled(),
-			})
-
-			if opErr := backup.NewOperation(cfg, registrySvc, storageSvc, logger).Run(ctx); opErr != nil {
-				logger.Error(ctx, "Backup command failed", opErr)
-				return cli.Exit("backup command failed", codes.InternalError)
-			}
-
-			logger.Info(ctx, "Backup command completed successfully")
-			return nil
-		},
+		Action: backupAction,
 	}
+}
+
+func backupAction(ctx context.Context, cmd *cli.Command) error {
+	logger := logging.GetLogger(ctx)
+	if logger == nil {
+		return cli.Exit("failed to retrieve logger", codes.InternalError)
+	}
+
+	operationID := logging.GenerateOperationID("backup")
+	logger = logger.WithContext("backup-cmd", operationID)
+
+	logger.Info(ctx, "Backup command initiated")
+
+	// Log command parameters for debugging
+	logger.Debug(ctx, "Parsing command parameters", logging.Fields{
+		"db_host":           cmd.String("db-host"),
+		"db_port":           cmd.Int("db-port"),
+		"db_user":           cmd.String("db-user"),
+		"db_password":       "***", // Don't log actual password
+		"db_backup_options": cmd.String("db-backup-options"),
+		"db_backup_binary":  cmd.String("db-backup-binary"),
+		"storage_url":       cmd.String("storage-url"),
+		"encryption_key":    "***", // Don't log actual key
+	})
+
+	cfg, err := parseConfig(cmd)
+	if err != nil {
+		logger.Error(ctx, "Failed to parse configuration", err)
+		return cli.Exit("backup command failed", codes.ParamsError)
+	}
+
+	logger.Debug(ctx, "Configuration validated successfully", logging.Fields{
+		"db_host":            cfg.MariaDB.Host,
+		"db_port":            cfg.MariaDB.Port,
+		"db_user":            cfg.MariaDB.User,
+		"storage_url":        cfg.Storage.URL,
+		"encryption_enabled": cfg.Encryption.Enabled(),
+	})
+
+	u, err := cfg.Storage.GetURL()
+	if err != nil {
+		logger.Error(ctx, "Failed to parse storage url", err)
+		return cli.Exit("backup command failed", codes.ParamsError)
+	}
+
+	storageSvc, err := storage.New(u)
+	if err != nil {
+		logger.Error(ctx, "Failed to initialize storage backend", err)
+		return cli.Exit("backup command failed", codes.InternalError)
+	}
+	defer func() {
+		if closeErr := storageSvc.Close(); closeErr != nil {
+			logger.Error(ctx, "Failed to close storage backend", closeErr)
+		}
+	}()
+
+	registrySvc := registry.NewService(storageSvc)
+
+	logger.Info(ctx, "Starting backup execution", logging.Fields{
+		"db_host":            cfg.MariaDB.Host,
+		"db_port":            cfg.MariaDB.Port,
+		"encryption_enabled": cfg.Encryption.Enabled(),
+	})
+
+	if opErr := backup.NewOperation(cfg, registrySvc, storageSvc, logger).Run(ctx); opErr != nil {
+		logger.Error(ctx, "Backup command failed", opErr)
+		return cli.Exit("backup command failed", codes.InternalError)
+	}
+
+	if !cmd.Bool("skip-retention") {
+		rflags := flags.ParseRetentionFlags(cmd)
+		rcfg := retention.Config{
+			MaxCount:    rflags.MaxCount,
+			MaxAge:      rflags.MaxAge,
+			KeepDaily:   rflags.KeepDaily,
+			KeepWeekly:  rflags.KeepWeekly,
+			KeepMonthly: rflags.KeepMonthly,
+			DryRun:      false,
+			Force:       false,
+		}
+
+		// Skip retention if no policies are configured
+		if retErr := rcfg.Validate(); retErr != nil {
+			logger.Warn(ctx, "Skipping retention: "+retErr.Error())
+		} else if opErr := retention.NewOperation(rcfg, registrySvc, storageSvc, logger).Run(ctx); opErr != nil {
+			logger.Error(ctx, "Retention command failed", opErr)
+			return cli.Exit("retention command failed", codes.InternalError)
+		}
+	}
+
+	logger.Info(ctx, "Backup command completed successfully")
+	return nil
 }

--- a/internal/cli/commands/backup/backup.go
+++ b/internal/cli/commands/backup/backup.go
@@ -91,6 +91,11 @@ func Command() *cli.Command {
 				logger.Error(ctx, "Failed to initialize storage backend", err)
 				return cli.Exit("backup command failed", codes.InternalError)
 			}
+			defer func() {
+				if closeErr := storageSvc.Close(); closeErr != nil {
+					logger.Error(ctx, "Failed to close storage backend", closeErr)
+				}
+			}()
 
 			registrySvc := registry.NewService(storageSvc)
 

--- a/internal/cli/commands/backup/backup.go
+++ b/internal/cli/commands/backup/backup.go
@@ -7,6 +7,8 @@ import (
 	"github.com/capcom6/mariadb-backup-s3/internal/cli/flags"
 	"github.com/capcom6/mariadb-backup-s3/internal/core/codes"
 	"github.com/capcom6/mariadb-backup-s3/internal/logging"
+	"github.com/capcom6/mariadb-backup-s3/internal/registry"
+	"github.com/capcom6/mariadb-backup-s3/internal/storage"
 	"github.com/capcom6/mariadb-backup-s3/pkg/cliutil"
 	"github.com/urfave/cli/v3"
 )
@@ -15,6 +17,7 @@ func Command() *cli.Command {
 	fl := flags.Database()
 	fl = append(fl, flags.Storage()...)
 	fl = append(fl, flags.Encryption()...)
+	fl = append(fl, flags.Retention()...)
 	fl = append(fl,
 		&cli.StringFlag{
 			Name:    "db-backup-options",
@@ -30,12 +33,6 @@ func Command() *cli.Command {
 				cliutil.DefaultValue("mariadb-backup"),
 			),
 		},
-		&cli.IntFlag{
-			Name:        "backup-limits-max-count",
-			Usage:       "maximum number of backups to retain (0 = unlimited)",
-			DefaultText: "0",
-			Sources:     cli.EnvVars("BACKUP__LIMITS__MAX_COUNT"),
-		},
 	)
 
 	return &cli.Command{
@@ -43,6 +40,9 @@ func Command() *cli.Command {
 		Aliases: []string{"b"},
 		Usage:   "Backup MariaDB database",
 		Flags:   fl,
+		Commands: []*cli.Command{
+			ListCommand(),
+		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			logger := logging.GetLogger(ctx)
 			if logger == nil {
@@ -56,59 +56,52 @@ func Command() *cli.Command {
 
 			// Log command parameters for debugging
 			logger.Debug(ctx, "Parsing command parameters", logging.Fields{
-				"db_host":                 cmd.String("db-host"),
-				"db_port":                 cmd.Int("db-port"),
-				"db_user":                 cmd.String("db-user"),
-				"db_password":             "***", // Don't log actual password
-				"db_backup_options":       cmd.String("db-backup-options"),
-				"db_backup_binary":        cmd.String("db-backup-binary"),
-				"backup_limits_max_count": cmd.Int("backup-limits-max-count"),
-				"storage_url":             cmd.String("storage-url"),
-				"encryption_key":          "***", // Don't log actual key
+				"db_host":           cmd.String("db-host"),
+				"db_port":           cmd.Int("db-port"),
+				"db_user":           cmd.String("db-user"),
+				"db_password":       "***", // Don't log actual password
+				"db_backup_options": cmd.String("db-backup-options"),
+				"db_backup_binary":  cmd.String("db-backup-binary"),
+				"storage_url":       cmd.String("storage-url"),
+				"encryption_key":    "***", // Don't log actual key
 			})
 
-			cfg := backup.DefaultConfig()
-
-			// Configure MariaDB settings
-			cfg.MariaDB.Host = cmd.String("db-host")
-			cfg.MariaDB.Port = cmd.Int("db-port")
-			cfg.MariaDB.User = cmd.String("db-user")
-			cfg.MariaDB.Password = cmd.String("db-password")
-			cfg.MariaDB.BackupOptions = cmd.String("db-backup-options")
-			cfg.MariaDB.BackupBinary = cmd.String("db-backup-binary")
-
-			// Configure backup limits
-			cfg.Backup.Limits.MaxCount = cmd.Int("backup-limits-max-count")
-
-			// Configure storage
-			cfg.Storage.URL = cmd.String("storage-url")
-
-			// Configure encryption
-			cfg.Encryption.EncryptionKey = cmd.String("encryption-key")
-
-			// Validate configuration
-			if err := cfg.Validate(); err != nil {
-				logger.Error(ctx, "Invalid configuration", err)
+			cfg, err := parseConfig(cmd)
+			if err != nil {
+				logger.Error(ctx, "Failed to parse configuration", err)
 				return cli.Exit("backup command failed", codes.ParamsError)
 			}
+
 			logger.Debug(ctx, "Configuration validated successfully", logging.Fields{
-				"db_host":                 cfg.MariaDB.Host,
-				"db_port":                 cfg.MariaDB.Port,
-				"db_user":                 cfg.MariaDB.User,
-				"storage_url":             cfg.Storage.URL,
-				"backup_limits_max_count": cfg.Backup.Limits.MaxCount,
-				"encryption_enabled":      cfg.Encryption.Enabled(),
+				"db_host":            cfg.MariaDB.Host,
+				"db_port":            cfg.MariaDB.Port,
+				"db_user":            cfg.MariaDB.User,
+				"storage_url":        cfg.Storage.URL,
+				"encryption_enabled": cfg.Encryption.Enabled(),
 			})
+
+			u, err := cfg.Storage.GetURL()
+			if err != nil {
+				logger.Error(ctx, "Failed to parse storage url", err)
+				return cli.Exit("backup command failed", codes.ParamsError)
+			}
+
+			storageSvc, err := storage.New(u)
+			if err != nil {
+				logger.Error(ctx, "Failed to initialize storage backend", err)
+				return cli.Exit("backup command failed", codes.InternalError)
+			}
+
+			registrySvc := registry.NewService(storageSvc)
 
 			logger.Info(ctx, "Starting backup execution", logging.Fields{
-				"db_host":                 cfg.MariaDB.Host,
-				"db_port":                 cfg.MariaDB.Port,
-				"backup_limits_max_count": cfg.Backup.Limits.MaxCount,
-				"encryption_enabled":      cfg.Encryption.Enabled(),
+				"db_host":            cfg.MariaDB.Host,
+				"db_port":            cfg.MariaDB.Port,
+				"encryption_enabled": cfg.Encryption.Enabled(),
 			})
 
-			if err := backup.NewOperation(cfg, logger).Run(ctx); err != nil {
-				logger.Error(ctx, "Backup command failed", err)
+			if opErr := backup.NewOperation(cfg, registrySvc, storageSvc, logger).Run(ctx); opErr != nil {
+				logger.Error(ctx, "Backup command failed", opErr)
 				return cli.Exit("backup command failed", codes.InternalError)
 			}
 

--- a/internal/cli/commands/backup/backup.go
+++ b/internal/cli/commands/backup/backup.go
@@ -47,10 +47,7 @@ func Command() *cli.Command {
 		Aliases: []string{"b"},
 		Usage:   "Backup MariaDB database",
 		Flags:   fl,
-		Commands: []*cli.Command{
-			ListCommand(),
-		},
-		Action: backupAction,
+		Action:  backupAction,
 	}
 }
 

--- a/internal/cli/commands/backup/config.go
+++ b/internal/cli/commands/backup/config.go
@@ -1,0 +1,35 @@
+package backup
+
+import (
+	"fmt"
+
+	"github.com/capcom6/mariadb-backup-s3/internal/backup"
+	"github.com/urfave/cli/v3"
+)
+
+func parseConfig(cmd *cli.Command) (backup.Config, error) {
+	cfg := backup.DefaultConfig()
+
+	cfg.Version = cmd.Root().Version
+
+	// Configure MariaDB settings
+	cfg.MariaDB.Host = cmd.String("db-host")
+	cfg.MariaDB.Port = cmd.Int("db-port")
+	cfg.MariaDB.User = cmd.String("db-user")
+	cfg.MariaDB.Password = cmd.String("db-password")
+	cfg.MariaDB.BackupOptions = cmd.String("db-backup-options")
+	cfg.MariaDB.BackupBinary = cmd.String("db-backup-binary")
+
+	// Configure storage
+	cfg.Storage.URL = cmd.String("storage-url")
+
+	// Configure encryption
+	cfg.Encryption.EncryptionKey = cmd.String("encryption-key")
+
+	// Validate configuration
+	if err := cfg.Validate(); err != nil {
+		return backup.Config{}, fmt.Errorf("failed to parse backup configuration: %w", err)
+	}
+
+	return cfg, nil
+}

--- a/internal/cli/commands/backup/list.go
+++ b/internal/cli/commands/backup/list.go
@@ -1,0 +1,72 @@
+package backup
+
+import (
+	"context"
+
+	"github.com/capcom6/mariadb-backup-s3/internal/cli/flags"
+	"github.com/capcom6/mariadb-backup-s3/internal/config"
+	"github.com/capcom6/mariadb-backup-s3/internal/core/codes"
+	"github.com/capcom6/mariadb-backup-s3/internal/logging"
+	"github.com/capcom6/mariadb-backup-s3/internal/registry"
+	"github.com/capcom6/mariadb-backup-s3/internal/storage"
+	"github.com/urfave/cli/v3"
+)
+
+func ListCommand() *cli.Command {
+	fl := flags.Storage()
+
+	return &cli.Command{
+		Name:  "list",
+		Usage: "List backups from registry",
+		Flags: fl,
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			logger := logging.GetLogger(ctx)
+			if logger == nil {
+				return cli.Exit("failed to retrieve logger", codes.InternalError)
+			}
+
+			u, err := (config.Storage{URL: cmd.String("storage-url")}).GetURL()
+			if err != nil {
+				logger.Error(ctx, "Failed to parse storage URL", err)
+				return cli.Exit("invalid storage url", codes.ParamsError)
+			}
+			backend, err := storage.New(u)
+			if err != nil {
+				logger.Error(ctx, "Failed to initialize storage backend", err)
+				return cli.Exit("failed to initialize storage backend", codes.InternalError)
+			}
+
+			registrySvc := registry.NewService(backend, registry.WithRecovery())
+
+			reg, err := registrySvc.Load(ctx)
+			if err != nil {
+				logger.Error(ctx, "Failed to load registry", err)
+				return cli.Exit("failed to load registry", codes.InternalError)
+			}
+
+			reg.SortByCreatedAtDesc()
+			printRegistryTable(ctx, logger, reg)
+
+			return nil
+		},
+	}
+}
+
+func printRegistryTable(ctx context.Context, logger logging.Logger, reg *registry.Registry) {
+	logger.Info(ctx, "Listing backups", logging.Fields{
+		"updated_at": reg.UpdatedAt,
+		"version":    reg.Version,
+		"count":      len(reg.Backups),
+	})
+
+	for _, v := range reg.Backups {
+		logger.Info(ctx, "Backup", logging.Fields{
+			"id":         v.ID,
+			"created_at": v.CreatedAt,
+			"status":     v.Status,
+			"encrypted":  v.Encrypted,
+			"size":       v.SizeBytes,
+			"filename":   v.Filename,
+		})
+	}
+}

--- a/internal/cli/commands/registry/list.go
+++ b/internal/cli/commands/registry/list.go
@@ -1,7 +1,8 @@
-package backup
+package registry
 
 import (
 	"context"
+	"errors"
 
 	"github.com/capcom6/mariadb-backup-s3/internal/cli/flags"
 	"github.com/capcom6/mariadb-backup-s3/internal/config"
@@ -14,11 +15,18 @@ import (
 
 func ListCommand() *cli.Command {
 	fl := flags.Storage()
+	fl = append(fl, &cli.BoolFlag{
+		Name:    "rebuild",
+		Aliases: []string{"r"},
+		Usage:   "Rebuild registry from storage if missing",
+		Value:   false,
+	})
 
 	return &cli.Command{
-		Name:  "list",
-		Usage: "List backups from registry",
-		Flags: fl,
+		Name:    "list",
+		Aliases: []string{"ls"},
+		Usage:   "List backups from registry (read-only by default, use --rebuild to rebuild if missing)",
+		Flags:   fl,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			logger := logging.GetLogger(ctx)
 			if logger == nil {
@@ -30,16 +38,33 @@ func ListCommand() *cli.Command {
 				logger.Error(ctx, "Failed to parse storage URL", err)
 				return cli.Exit("invalid storage url", codes.ParamsError)
 			}
-			backend, err := storage.New(u)
+
+			storageSvc, err := storage.New(u)
 			if err != nil {
 				logger.Error(ctx, "Failed to initialize storage backend", err)
 				return cli.Exit("failed to initialize storage backend", codes.InternalError)
 			}
+			defer func() {
+				if closeErr := storageSvc.Close(); closeErr != nil {
+					logger.Error(ctx, "Failed to close storage backend", closeErr)
+				}
+			}()
 
-			registrySvc := registry.NewService(backend, registry.WithRecovery())
+			// Conditionally enable recovery based on --rebuild flag
+			var opts []registry.Option
+			if cmd.Bool("rebuild") {
+				opts = append(opts, registry.WithRecovery())
+			}
+			registrySvc := registry.NewService(storageSvc, opts...)
 
 			reg, err := registrySvc.Load(ctx)
 			if err != nil {
+				// If registry not found and not rebuilding, return empty list
+				if errors.Is(err, storage.ErrNotFound) && !cmd.Bool("rebuild") {
+					logger.Warn(ctx, "Registry not found, returning empty list", nil)
+					printRegistryTable(ctx, logger, registry.New())
+					return nil
+				}
 				logger.Error(ctx, "Failed to load registry", err)
 				return cli.Exit("failed to load registry", codes.InternalError)
 			}

--- a/internal/cli/commands/registry/registry.go
+++ b/internal/cli/commands/registry/registry.go
@@ -1,0 +1,20 @@
+package registry
+
+import (
+	"github.com/capcom6/mariadb-backup-s3/internal/cli/flags"
+	"github.com/urfave/cli/v3"
+)
+
+func Command() *cli.Command {
+	fl := flags.Storage()
+
+	return &cli.Command{
+		Name:    "registry",
+		Aliases: []string{"reg"},
+		Usage:   "Manage registry",
+		Flags:   fl,
+		Commands: []*cli.Command{
+			ListCommand(),
+		},
+	}
+}

--- a/internal/cli/commands/restore/config.go
+++ b/internal/cli/commands/restore/config.go
@@ -1,0 +1,22 @@
+package restore
+
+import (
+	"fmt"
+
+	"github.com/capcom6/mariadb-backup-s3/internal/restore"
+	"github.com/urfave/cli/v3"
+)
+
+func parseConfig(cmd *cli.Command) (restore.Config, error) {
+	cfg := restore.DefaultConfig()
+
+	cfg.Storage.URL = cmd.String("storage-url")
+	cfg.Encryption.EncryptionKey = cmd.String("encryption-key")
+	cfg.TargetDir = cmd.String("target-dir")
+
+	if err := cfg.Validate(); err != nil {
+		return restore.Config{}, fmt.Errorf("failed to parse restore configuration: %w", err)
+	}
+
+	return cfg, nil
+}

--- a/internal/cli/commands/restore/errors.go
+++ b/internal/cli/commands/restore/errors.go
@@ -1,0 +1,8 @@
+package restore
+
+import "errors"
+
+var (
+	ErrBackupNotFound = errors.New("backup not found")
+	ErrInvalidParams  = errors.New("invalid parameters")
+)

--- a/internal/cli/commands/restore/restore.go
+++ b/internal/cli/commands/restore/restore.go
@@ -148,12 +148,15 @@ func resolveBackupSelection(ctx context.Context, cmd *cli.Command) (string, erro
 	if err != nil {
 		return "", fmt.Errorf("failed to parse storage URL: %w", err)
 	}
-	backend, err := storage.New(u)
+	storageSvc, err := storage.New(u)
 	if err != nil {
 		return "", fmt.Errorf("failed to initialize storage backend: %w", err)
 	}
+	defer func() {
+		_ = storageSvc.Close()
+	}()
 
-	registrySvc := registry.NewService(backend, registry.WithRecovery())
+	registrySvc := registry.NewService(storageSvc, registry.WithRecovery())
 	reg, err := registrySvc.Load(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to load registry: %w", err)

--- a/internal/cli/commands/restore/restore.go
+++ b/internal/cli/commands/restore/restore.go
@@ -2,11 +2,16 @@ package restore
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/capcom6/mariadb-backup-s3/internal/cli/flags"
+	"github.com/capcom6/mariadb-backup-s3/internal/config"
 	"github.com/capcom6/mariadb-backup-s3/internal/core/codes"
 	"github.com/capcom6/mariadb-backup-s3/internal/logging"
+	"github.com/capcom6/mariadb-backup-s3/internal/registry"
 	"github.com/capcom6/mariadb-backup-s3/internal/restore"
+	"github.com/capcom6/mariadb-backup-s3/internal/storage"
 	"github.com/urfave/cli/v3"
 )
 
@@ -19,6 +24,14 @@ func Command() *cli.Command {
 			Usage:    "target directory",
 			Required: true,
 			Sources:  cli.EnvVars("RESTORE__TARGET_DIR"),
+		},
+		&cli.BoolFlag{
+			Name:  "latest",
+			Usage: "restore latest ready backup from registry",
+		},
+		&cli.StringFlag{
+			Name:  "backup-id",
+			Usage: "restore backup by registry backup ID",
 		},
 	)
 
@@ -36,7 +49,7 @@ func Command() *cli.Command {
 				},
 			},
 		},
-		ArgsUsage: "backup_name.tar.gz",
+		ArgsUsage: "[backup_name.tar.gz | --latest | --backup-id=<id>]",
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			logger := logging.GetLogger(ctx)
 			if logger == nil {
@@ -48,32 +61,30 @@ func Command() *cli.Command {
 
 			logger.Info(ctx, "Restore command initiated")
 
-			backupFile := cmd.StringArg("backup-file")
-			if backupFile == "" {
-				err := cli.Exit("backup file name is required", codes.ParamsError)
-				logger.Error(ctx, "Backup file name is required", err)
-				return err
-			}
-
-			targetDir := cmd.String("target-dir")
-
 			// Log command parameters for debugging
 			logger.Debug(ctx, "Parsing command parameters", logging.Fields{
-				"backup_file":    backupFile,
-				"target_dir":     targetDir,
+				"target_dir":     cmd.String("target-dir"),
 				"storage_url":    cmd.String("storage-url"),
 				"encryption_key": "***", // Don't log actual key
 			})
 
-			cfg := restore.DefaultConfig()
-
-			cfg.Storage.URL = cmd.String("storage-url")
-			cfg.Encryption.EncryptionKey = cmd.String("encryption-key")
-			cfg.TargetDir = targetDir
-
-			if err := cfg.Validate(); err != nil {
+			cfg, err := parseConfig(cmd)
+			if err != nil {
 				logger.Error(ctx, "Restore command failed", err)
 				return cli.Exit("restore command failed", codes.ParamsError)
+			}
+
+			backupFile, selErr := resolveBackupSelection(ctx, cmd)
+			if selErr != nil {
+				if errors.Is(selErr, ErrInvalidParams) {
+					err := cli.Exit(selErr.Error(), codes.ParamsError)
+					logger.Error(ctx, "Failed to resolve backup selection", err)
+					return err
+				}
+
+				err := cli.Exit(selErr.Error(), codes.InternalError)
+				logger.Error(ctx, "Failed to resolve backup selection", err)
+				return err
 			}
 
 			// Validate configuration (debug visibility)
@@ -90,8 +101,8 @@ func Command() *cli.Command {
 				"encryption_enabled": cfg.Encryption.Enabled(),
 			})
 
-			if err := restore.NewOperation(cfg, logger).Run(ctx, backupFile); err != nil {
-				logger.Error(ctx, "Restore command failed", err)
+			if opErr := restore.NewOperation(cfg, logger).Run(ctx, backupFile); opErr != nil {
+				logger.Error(ctx, "Restore command failed", opErr)
 				return cli.Exit("restore command failed", codes.InternalError)
 			}
 
@@ -99,4 +110,70 @@ func Command() *cli.Command {
 			return nil
 		},
 	}
+}
+
+func resolveBackupSelection(ctx context.Context, cmd *cli.Command) (string, error) {
+	backupFile := cmd.StringArg("backup-file")
+	latest := cmd.Bool("latest")
+	backupID := cmd.String("backup-id")
+
+	selected := 0
+	if backupFile != "" {
+		selected++
+	}
+	if latest {
+		selected++
+	}
+	if backupID != "" {
+		selected++
+	}
+	if selected == 0 {
+		return "", fmt.Errorf(
+			"%w: specify one of: backup filename argument, --latest, or --backup-id",
+			ErrInvalidParams,
+		)
+	}
+	if selected > 1 {
+		return "", fmt.Errorf(
+			"%w: use only one selector: backup filename argument, --latest, or --backup-id",
+			ErrInvalidParams,
+		)
+	}
+	if backupFile != "" {
+		return backupFile, nil
+	}
+
+	storageURL := cmd.String("storage-url")
+	u, err := (config.Storage{URL: storageURL}).GetURL()
+	if err != nil {
+		return "", fmt.Errorf("failed to parse storage URL: %w", err)
+	}
+	backend, err := storage.New(u)
+	if err != nil {
+		return "", fmt.Errorf("failed to initialize storage backend: %w", err)
+	}
+
+	registrySvc := registry.NewService(backend, registry.WithRecovery())
+	reg, err := registrySvc.Load(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to load registry: %w", err)
+	}
+
+	if latest {
+		reg.SortByCreatedAtDesc()
+		for _, b := range reg.Backups {
+			if b.Status == registry.StatusReady {
+				return b.Filename, nil
+			}
+		}
+		return "", fmt.Errorf("%w: no ready backups found in registry", ErrBackupNotFound)
+	}
+
+	for _, b := range reg.Backups {
+		if b.ID == backupID && b.Status == registry.StatusReady {
+			return b.Filename, nil
+		}
+	}
+
+	return "", fmt.Errorf("%w: backup-id not found in ready registry entries", ErrBackupNotFound)
 }

--- a/internal/cli/commands/retention/config.go
+++ b/internal/cli/commands/retention/config.go
@@ -1,0 +1,31 @@
+package retention
+
+import (
+	"fmt"
+
+	"github.com/capcom6/mariadb-backup-s3/internal/cli/flags"
+	"github.com/capcom6/mariadb-backup-s3/internal/retention"
+	"github.com/urfave/cli/v3"
+)
+
+func parseConfig(cmd *cli.Command) (retention.Config, error) {
+	f := flags.ParseRetentionFlags(cmd)
+
+	// Parse retention configuration
+	retentionCfg := retention.Config{
+		MaxCount:    f.MaxCount,
+		MaxAge:      f.MaxAge,
+		KeepDaily:   f.KeepDaily,
+		KeepWeekly:  f.KeepWeekly,
+		KeepMonthly: f.KeepMonthly,
+		DryRun:      cmd.Bool("dry-run"),
+		Force:       cmd.Bool("force"),
+	}
+
+	// Validate configuration
+	if err := retentionCfg.Validate(); err != nil {
+		return retention.Config{}, fmt.Errorf("failed to parse retention configuration: %w", err)
+	}
+
+	return retentionCfg, nil
+}

--- a/internal/cli/commands/retention/retention.go
+++ b/internal/cli/commands/retention/retention.go
@@ -1,0 +1,122 @@
+package retention
+
+import (
+	"context"
+
+	"github.com/capcom6/mariadb-backup-s3/internal/cli/flags"
+	"github.com/capcom6/mariadb-backup-s3/internal/config"
+	"github.com/capcom6/mariadb-backup-s3/internal/core/codes"
+	"github.com/capcom6/mariadb-backup-s3/internal/logging"
+	"github.com/capcom6/mariadb-backup-s3/internal/registry"
+	"github.com/capcom6/mariadb-backup-s3/internal/retention"
+	"github.com/capcom6/mariadb-backup-s3/internal/storage"
+	"github.com/urfave/cli/v3"
+)
+
+func Command() *cli.Command {
+	fl := flags.Storage()
+	fl = append(fl, flags.Retention()...)
+	fl = append(fl,
+		&cli.BoolFlag{
+			Name:     "dry-run",
+			Usage:    "show what would be deleted without actually deleting",
+			Sources:  cli.EnvVars("RETENTION__DRY_RUN"),
+			Category: "Retention",
+		},
+		&cli.BoolFlag{
+			Name:     "force",
+			Usage:    "continue even if errors occur",
+			Sources:  cli.EnvVars("RETENTION__FORCE"),
+			Category: "Retention",
+		},
+	)
+
+	return &cli.Command{
+		Name:    "retention",
+		Aliases: []string{"ret"},
+		Usage:   "Apply retention policies to backups",
+		Flags:   fl,
+		Action:  retentionAction,
+	}
+}
+
+func retentionAction(ctx context.Context, cmd *cli.Command) error {
+	logger := logging.GetLogger(ctx)
+	if logger == nil {
+		return cli.Exit("failed to retrieve logger", codes.InternalError)
+	}
+
+	operationID := logging.GenerateOperationID("retention")
+	logger = logger.WithContext("retention-cmd", operationID)
+
+	logger.Info(ctx, "Retention command initiated")
+
+	// Log command parameters for debugging
+	logger.Debug(ctx, "Parsing command parameters", logging.Fields{
+		"storage_url":  cmd.String("storage-url"),
+		"max_count":    cmd.Int("retention-count"),
+		"max_age":      cmd.Duration("max-age"),
+		"keep_daily":   cmd.Int("keep-daily"),
+		"keep_weekly":  cmd.Int("keep-weekly"),
+		"keep_monthly": cmd.Int("keep-monthly"),
+		"dry_run":      cmd.Bool("dry-run"),
+		"force":        cmd.Bool("force"),
+	})
+
+	cfg, err := parseConfig(cmd)
+	if err != nil {
+		logger.Error(ctx, "Failed to parse configuration", err)
+		return cli.Exit("retention command failed", codes.ParamsError)
+	}
+
+	logger.Debug(ctx, "Configuration validated successfully", logging.Fields{
+		"max_count":    cfg.MaxCount,
+		"max_age":      cfg.MaxAge.String(),
+		"keep_daily":   cfg.KeepDaily,
+		"keep_weekly":  cfg.KeepWeekly,
+		"keep_monthly": cfg.KeepMonthly,
+		"dry_run":      cfg.DryRun,
+		"force":        cfg.Force,
+	})
+
+	storageCfg := config.Storage{
+		URL: cmd.String("storage-url"),
+	}
+	u, err := storageCfg.GetURL()
+	if err != nil {
+		logger.Error(ctx, "Failed to parse storage url", err)
+		return cli.Exit("retention command failed", codes.ParamsError)
+	}
+
+	storageSvc, err := storage.New(u)
+	if err != nil {
+		logger.Error(ctx, "Failed to initialize storage backend", err)
+		return cli.Exit("retention command failed", codes.InternalError)
+	}
+	defer func() {
+		if closeErr := storageSvc.Close(); closeErr != nil {
+			logger.Error(ctx, "Failed to close storage backend", closeErr)
+		}
+	}()
+
+	registrySvc := registry.NewService(storageSvc)
+
+	logger.Info(ctx, "Starting retention execution", logging.Fields{
+		"storage_url":  storageCfg.URL,
+		"max_count":    cfg.MaxCount,
+		"max_age":      cfg.MaxAge.String(),
+		"keep_daily":   cfg.KeepDaily,
+		"keep_weekly":  cfg.KeepWeekly,
+		"keep_monthly": cfg.KeepMonthly,
+		"dry_run":      cfg.DryRun,
+		"force":        cfg.Force,
+	})
+
+	if opErr := retention.NewOperation(cfg, registrySvc, storageSvc, logger).Run(ctx); opErr != nil {
+		logger.Error(ctx, "Retention command failed", opErr)
+		return cli.Exit("retention command failed", codes.InternalError)
+	}
+
+	logger.Info(ctx, "Retention command completed successfully")
+	return nil
+}

--- a/internal/cli/flags/retention.go
+++ b/internal/cli/flags/retention.go
@@ -1,0 +1,17 @@
+package flags
+
+import "github.com/urfave/cli/v3"
+
+func Retention() []cli.Flag {
+	return []cli.Flag{
+		&cli.IntFlag{
+			Name:        "retention-count",
+			Aliases:     []string{"backup-limits-max-count"},
+			Usage:       "number of backups to retain (0 = unlimited)",
+			Required:    false,
+			DefaultText: "unlimited",
+			Sources:     cli.EnvVars("RETENTION__COUNT", "BACKUP__LIMITS__MAX_COUNT"),
+			Category:    "Retention",
+		},
+	}
+}

--- a/internal/cli/flags/retention.go
+++ b/internal/cli/flags/retention.go
@@ -1,6 +1,10 @@
 package flags
 
-import "github.com/urfave/cli/v3"
+import (
+	"time"
+
+	"github.com/urfave/cli/v3"
+)
 
 func Retention() []cli.Flag {
 	return []cli.Flag{
@@ -13,5 +17,51 @@ func Retention() []cli.Flag {
 			Sources:     cli.EnvVars("RETENTION__COUNT", "BACKUP__LIMITS__MAX_COUNT"),
 			Category:    "Retention",
 		},
+		&cli.DurationFlag{
+			Name:        "max-age",
+			Usage:       "maximum age of backups to keep (e.g. 24h, 168h, 672h)",
+			DefaultText: "unlimited",
+			Sources:     cli.EnvVars("RETENTION__MAX_AGE"),
+			Category:    "Retention",
+		},
+		&cli.IntFlag{
+			Name:        "keep-daily",
+			Usage:       "number of daily backups to keep",
+			DefaultText: "unlimited",
+			Sources:     cli.EnvVars("RETENTION__KEEP_DAILY"),
+			Category:    "Retention",
+		},
+		&cli.IntFlag{
+			Name:        "keep-weekly",
+			Usage:       "number of weekly backups to keep",
+			DefaultText: "unlimited",
+			Sources:     cli.EnvVars("RETENTION__KEEP_WEEKLY"),
+			Category:    "Retention",
+		},
+		&cli.IntFlag{
+			Name:        "keep-monthly",
+			Usage:       "number of monthly backups to keep",
+			DefaultText: "unlimited",
+			Sources:     cli.EnvVars("RETENTION__KEEP_MONTHLY"),
+			Category:    "Retention",
+		},
+	}
+}
+
+type RetentionFlags struct {
+	MaxCount    int
+	MaxAge      time.Duration
+	KeepDaily   int
+	KeepWeekly  int
+	KeepMonthly int
+}
+
+func ParseRetentionFlags(cmd *cli.Command) RetentionFlags {
+	return RetentionFlags{
+		MaxCount:    cmd.Int("retention-count"),
+		MaxAge:      cmd.Duration("max-age"),
+		KeepDaily:   cmd.Int("keep-daily"),
+		KeepWeekly:  cmd.Int("keep-weekly"),
+		KeepMonthly: cmd.Int("keep-monthly"),
 	}
 }

--- a/internal/logging/config.go
+++ b/internal/logging/config.go
@@ -56,7 +56,7 @@ func DefaultConfig() Config {
 	case "":
 		output = os.Stdout
 	default:
-		f, err := os.Create(os.Getenv("LOG_OUTPUT"))
+		f, err := os.Create(os.Getenv("LOG_OUTPUT")) //nolint:gosec // acceptable
 		if err != nil {
 			fmt.Fprintf(
 				os.Stderr,

--- a/internal/registry/domain.go
+++ b/internal/registry/domain.go
@@ -1,0 +1,141 @@
+package registry
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	currentVersion = 1
+	fileName       = ".backup-registry.json"
+
+	StatusReady   = "ready"
+	StatusFailed  = "failed"
+	StatusDeleted = "deleted"
+)
+
+type Registry struct {
+	Version   int           `json:"version"`
+	UpdatedAt time.Time     `json:"updated_at"`
+	Backups   []BackupEntry `json:"backups"`
+}
+
+type BackupEntry struct {
+	ID         string              `json:"id"`
+	Filename   string              `json:"filename"`
+	CreatedAt  time.Time           `json:"created_at"`
+	SizeBytes  int64               `json:"size_bytes"`
+	SHA256     string              `json:"sha256"`
+	Status     string              `json:"status"`
+	Encrypted  bool                `json:"encrypted"`
+	Encryption *EncryptionMetadata `json:"encryption,omitempty"`
+	Tool       *ToolMetadata       `json:"tool,omitempty"`
+}
+
+func NewBackupEntry(
+	filename string,
+	createdAt time.Time,
+	sizeBytes int64,
+	sha256 string,
+	status string,
+	encrypted bool,
+	encryption *EncryptionMetadata,
+	tool *ToolMetadata,
+) BackupEntry {
+	return BackupEntry{
+		ID:         createdAt.Format("2006-01-02-15-04-05") + "-" + sha256[:8],
+		Filename:   filename,
+		CreatedAt:  createdAt,
+		SizeBytes:  sizeBytes,
+		SHA256:     sha256,
+		Encrypted:  encrypted,
+		Encryption: encryption,
+		Tool:       tool,
+		Status:     status,
+	}
+}
+
+type EncryptionMetadata struct {
+	Algorithm string `json:"algorithm,omitempty"`
+}
+
+type ToolMetadata struct {
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+func New() *Registry {
+	return &Registry{
+		Version:   currentVersion,
+		UpdatedAt: time.Now().UTC(),
+		Backups:   make([]BackupEntry, 0),
+	}
+}
+
+func (r *Registry) Validate() error {
+	if r.Version != currentVersion {
+		return fmt.Errorf("%w: unsupported registry version %d", ErrValidationFailed, r.Version)
+	}
+	if r.UpdatedAt.IsZero() {
+		return fmt.Errorf("%w: updated_at is required", ErrValidationFailed)
+	}
+
+	seenIDs := make(map[string]struct{}, len(r.Backups))
+	seenFiles := make(map[string]struct{}, len(r.Backups))
+
+	for i := range r.Backups {
+		if err := r.Backups[i].Validate(); err != nil {
+			return fmt.Errorf("invalid backup entry %d: %w", i, err)
+		}
+		if _, exists := seenIDs[r.Backups[i].ID]; exists {
+			return fmt.Errorf("%w: duplicate backup id: %s", ErrValidationFailed, r.Backups[i].ID)
+		}
+		if _, exists := seenFiles[r.Backups[i].Filename]; exists {
+			return fmt.Errorf("%w: duplicate backup filename: %s", ErrValidationFailed, r.Backups[i].Filename)
+		}
+		seenIDs[r.Backups[i].ID] = struct{}{}
+		seenFiles[r.Backups[i].Filename] = struct{}{}
+	}
+
+	return nil
+}
+
+func (r *Registry) SortByCreatedAtDesc() {
+	sort.Slice(r.Backups, func(i, j int) bool {
+		return r.Backups[i].CreatedAt.After(r.Backups[j].CreatedAt)
+	})
+}
+
+func (b *BackupEntry) Validate() error {
+	if strings.TrimSpace(b.ID) == "" {
+		return fmt.Errorf("%w: id is required", ErrValidationFailed)
+	}
+	if strings.TrimSpace(b.Filename) == "" {
+		return fmt.Errorf("%w: filename is required", ErrValidationFailed)
+	}
+	if b.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: created_at is required", ErrValidationFailed)
+	}
+	if b.SizeBytes < 0 {
+		return fmt.Errorf("%w: size_bytes must be >= 0", ErrValidationFailed)
+	}
+	if strings.TrimSpace(b.SHA256) == "" {
+		return fmt.Errorf("%w: sha256 is required", ErrValidationFailed)
+	}
+	if !isValidStatus(b.Status) {
+		return fmt.Errorf("%w: unsupported status: %s", ErrValidationFailed, b.Status)
+	}
+
+	return nil
+}
+
+func isValidStatus(s string) bool {
+	switch s {
+	case StatusReady, StatusFailed, StatusDeleted:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/registry/errors.go
+++ b/internal/registry/errors.go
@@ -1,0 +1,7 @@
+package registry
+
+import "errors"
+
+var (
+	ErrValidationFailed = errors.New("validation failed")
+)

--- a/internal/registry/options.go
+++ b/internal/registry/options.go
@@ -1,0 +1,13 @@
+package registry
+
+type options struct {
+	withRecovery bool
+}
+
+type Option func(*options)
+
+func WithRecovery() Option {
+	return func(o *options) {
+		o.withRecovery = true
+	}
+}

--- a/internal/registry/service.go
+++ b/internal/registry/service.go
@@ -1,0 +1,171 @@
+package registry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/capcom6/mariadb-backup-s3/internal/storage"
+)
+
+type Service struct {
+	storage storage.Backend
+
+	options options
+}
+
+func NewService(storage storage.Backend, opts ...Option) *Service {
+	options := new(options)
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	return &Service{
+		storage: storage,
+
+		options: *options,
+	}
+}
+
+func (s *Service) Load(ctx context.Context) (*Registry, error) {
+	buf := bytes.Buffer{}
+
+	if err := s.storage.Download(ctx, fileName, &buf); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return s.rebuild(ctx)
+		}
+		return nil, fmt.Errorf("failed to download registry: %w", err)
+	}
+
+	reg, err := s.parse(&buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return reg, nil
+}
+
+func (s *Service) Append(ctx context.Context, b BackupEntry) (*Registry, error) {
+	reg, err := s.Load(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	reg.Backups = append(reg.Backups, b)
+
+	if saveErr := s.save(ctx, reg); saveErr != nil {
+		return nil, saveErr
+	}
+
+	return reg, nil
+}
+
+func (s *Service) MarkDeleted(ctx context.Context, id string) error {
+	reg, err := s.Load(ctx)
+	if err != nil {
+		return err
+	}
+
+	for i, b := range reg.Backups {
+		if b.ID == id {
+			reg.Backups[i].Status = StatusDeleted
+			break
+		}
+	}
+
+	return s.save(ctx, reg)
+}
+
+func (s *Service) parse(r io.Reader) (*Registry, error) {
+	var reg Registry
+	dec := json.NewDecoder(r)
+	if err := dec.Decode(&reg); err != nil {
+		return nil, fmt.Errorf("failed to decode registry: %w", err)
+	}
+
+	if err := reg.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &reg, nil
+}
+
+func (s *Service) rebuild(ctx context.Context) (*Registry, error) {
+	if !s.options.withRecovery {
+		return New(), nil
+	}
+
+	files, err := s.storage.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list storage objects: %w", err)
+	}
+
+	entries := make([]BackupEntry, 0, len(files))
+	for _, filename := range files {
+		if filename == fileName || strings.HasSuffix(filename, "/") {
+			continue
+		}
+
+		createdAt, ok := backupTimeFromFilename(filename)
+		if !ok {
+			continue
+		}
+
+		encrypted := strings.HasSuffix(filename, ".enc")
+		entries = append(entries, BackupEntry{
+			ID:        createdAt.Format("2006-01-02-15-04-05"),
+			Filename:  filename,
+			CreatedAt: createdAt,
+			SizeBytes: 0,
+			SHA256:    "unknown",
+			Encrypted: encrypted,
+			Status:    StatusReady,
+			Tool: &ToolMetadata{
+				Name:    "mariadb-backup-s3",
+				Version: "unknown",
+			},
+			Encryption: nil,
+		})
+	}
+
+	if len(entries) == 0 {
+		return New(), nil
+	}
+
+	reg := New()
+	reg.Backups = entries
+	reg.SortByCreatedAtDesc()
+
+	if saveErr := s.save(ctx, reg); saveErr != nil {
+		return nil, saveErr
+	}
+
+	return reg, nil
+}
+
+func (s *Service) save(ctx context.Context, reg *Registry) error {
+	var buf bytes.Buffer
+	if err := reg.Validate(); err != nil {
+		return err
+	}
+
+	reg.SortByCreatedAtDesc()
+	reg.UpdatedAt = time.Now().UTC()
+
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(reg); err != nil {
+		return fmt.Errorf("failed to encode registry: %w", err)
+	}
+
+	if err := s.storage.Upload(ctx, fileName, &buf); err != nil {
+		return fmt.Errorf("failed to upload registry: %w", err)
+	}
+
+	return nil
+}

--- a/internal/registry/utils.go
+++ b/internal/registry/utils.go
@@ -1,0 +1,17 @@
+package registry
+
+import (
+	"strings"
+	"time"
+)
+
+func backupTimeFromFilename(filename string) (time.Time, bool) {
+	name := strings.TrimSuffix(filename, ".enc")
+	name = strings.TrimSuffix(name, ".tar.gz")
+	tm, err := time.ParseInLocation("2006-01-02-15-04-05", name, time.UTC)
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	return tm.UTC(), true
+}

--- a/internal/retention/config.go
+++ b/internal/retention/config.go
@@ -1,0 +1,62 @@
+package retention
+
+import (
+	"fmt"
+	"time"
+)
+
+type Config struct {
+	// Maximum number of backups to keep (0 = unlimited)
+	MaxCount int
+
+	// Maximum age of backups to keep (0 = unlimited)
+	MaxAge time.Duration
+
+	// Number of daily backups to keep (0 = disable)
+	KeepDaily int
+
+	// Number of weekly backups to keep (0 = disable)
+	KeepWeekly int
+
+	// Number of monthly backups to keep (0 = disable)
+	KeepMonthly int
+
+	// Dry run mode - only report what would be deleted
+	DryRun bool
+
+	// Force retention - ignore errors and continue
+	Force bool
+}
+
+func (c Config) Validate() error {
+	if c.MaxCount < 0 {
+		return fmt.Errorf("%w: max count must be >= 0", ErrValidationFailed)
+	}
+
+	if c.MaxAge < 0 {
+		return fmt.Errorf("%w: max age must be >= 0", ErrValidationFailed)
+	}
+
+	if c.KeepDaily < 0 {
+		return fmt.Errorf("%w: keep daily must be >= 0", ErrValidationFailed)
+	}
+
+	if c.KeepWeekly < 0 {
+		return fmt.Errorf("%w: keep weekly must be >= 0", ErrValidationFailed)
+	}
+
+	if c.KeepMonthly < 0 {
+		return fmt.Errorf("%w: keep monthly must be >= 0", ErrValidationFailed)
+	}
+
+	// Validate that at least one retention policy is enabled
+	if c.MaxCount == 0 && c.MaxAge == 0 && c.KeepDaily == 0 && c.KeepWeekly == 0 && c.KeepMonthly == 0 {
+		return fmt.Errorf("%w: at least one retention policy must be enabled", ErrValidationFailed)
+	}
+
+	return nil
+}
+
+func (c Config) IsEmpty() bool {
+	return c.MaxCount == 0 && c.MaxAge == 0 && c.KeepDaily == 0 && c.KeepWeekly == 0 && c.KeepMonthly == 0
+}

--- a/internal/retention/errors.go
+++ b/internal/retention/errors.go
@@ -1,0 +1,26 @@
+package retention
+
+import "errors"
+
+var (
+	// ErrValidationFailed indicates configuration validation failed.
+	ErrValidationFailed = errors.New("retention validation failed")
+
+	// ErrRegistryLoadFailed indicates failure to load backup registry.
+	ErrRegistryLoadFailed = errors.New("failed to load backup registry")
+
+	// ErrRegistryUpdateFailed indicates failure to update backup registry.
+	ErrRegistryUpdateFailed = errors.New("failed to update backup registry")
+
+	// ErrStorageOperationFailed indicates failure in storage operation.
+	ErrStorageOperationFailed = errors.New("storage operation failed")
+
+	// ErrRetentionPolicyConflict indicates conflicting retention policies.
+	ErrRetentionPolicyConflict = errors.New("retention policy conflict")
+
+	// ErrBackupNotFound indicates backup not found in registry.
+	ErrBackupNotFound = errors.New("backup not found")
+
+	// ErrBackupDeleteFailed indicates failure to delete backup file.
+	ErrBackupDeleteFailed = errors.New("failed to delete backup file")
+)

--- a/internal/retention/operation.go
+++ b/internal/retention/operation.go
@@ -1,0 +1,540 @@
+package retention
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/capcom6/mariadb-backup-s3/internal/logging"
+	"github.com/capcom6/mariadb-backup-s3/internal/registry"
+	"github.com/capcom6/mariadb-backup-s3/internal/storage"
+)
+
+type Operation struct {
+	config Config
+
+	// Registry service for backup metadata operations
+	registrySvc *registry.Service
+
+	// Storage backend for file operations
+	storage storage.Backend
+
+	// Logger for structured logging
+	logger logging.Logger
+}
+
+func NewOperation(
+	config Config,
+	registrySvc *registry.Service,
+	storage storage.Backend,
+	logger logging.Logger,
+) *Operation {
+	return &Operation{
+		config: config,
+
+		registrySvc: registrySvc,
+
+		storage: storage,
+
+		logger: logger,
+	}
+}
+
+// Run executes the retention operation with staged execution.
+func (o *Operation) Run(ctx context.Context) error {
+	ctx = logging.WithComponent(ctx, "retention")
+
+	o.logger.Info(ctx, "Starting retention operation", logging.Fields{
+		"max_count":    o.config.MaxCount,
+		"max_age":      o.config.MaxAge.String(),
+		"keep_daily":   o.config.KeepDaily,
+		"keep_weekly":  o.config.KeepWeekly,
+		"keep_monthly": o.config.KeepMonthly,
+		"dry_run":      o.config.DryRun,
+		"force":        o.config.Force,
+	})
+
+	if o.config.IsEmpty() {
+		o.logger.Info(ctx, "No retention policies enabled, skipping retention operation")
+		return nil
+	}
+
+	start := time.Now()
+	defer func() {
+		duration := time.Since(start)
+		o.logger.Info(ctx, "Retention operation completed", logging.Fields{
+			"duration": duration.String(),
+		})
+	}()
+
+	var err error
+
+	// Stage 1: Load and validate registry
+	var reg *registry.Registry
+	if reg, err = o.loadRegistry(ctx); err != nil {
+		return fmt.Errorf("failed to load registry: %w", err)
+	}
+
+	// Stage 2: Filter and categorize backups
+	var readyBackups []registry.BackupEntry
+	if readyBackups, err = o.filterBackups(ctx, reg); err != nil {
+		return fmt.Errorf("failed to filter backups: %w", err)
+	}
+
+	// Stage 3: Apply retention policies
+	var toRemove []registry.BackupEntry
+	if toRemove, err = o.applyRetentionPolicies(ctx, readyBackups); err != nil {
+		return fmt.Errorf("failed to apply retention policies: %w", err)
+	}
+
+	// Stage 4: Execute retention actions
+	var successfullyDeleted []registry.BackupEntry
+	if successfullyDeleted, err = o.executeRetentionActions(ctx, toRemove); err != nil {
+		return fmt.Errorf("failed to execute retention actions: %w", err)
+	}
+
+	// Stage 5: Update registry
+	if updErr := o.updateRegistry(ctx, successfullyDeleted); updErr != nil {
+		return fmt.Errorf("failed to update registry: %w", updErr)
+	}
+
+	return nil
+}
+
+// loadRegistry loads the backup registry from storage.
+func (o *Operation) loadRegistry(ctx context.Context) (*registry.Registry, error) {
+	o.logger.Info(ctx, "Stage 1: Load registry")
+	start := time.Now()
+	defer func() {
+		duration := time.Since(start)
+		o.logger.Info(ctx, "Stage 1 completed", logging.Fields{
+			"duration": duration.String(),
+		})
+	}()
+
+	registry, err := o.registrySvc.Load(ctx)
+	if err != nil {
+		o.logger.Error(ctx, "Failed to load backup registry", err)
+		return nil, fmt.Errorf("%w: %w", ErrRegistryLoadFailed, err)
+	}
+
+	// Log additional context about loaded registry
+	o.logger.Debug(ctx, "Registry loaded", logging.Fields{
+		"backup_count":     len(registry.Backups),
+		"registry_version": registry.Version,
+		"registry_updated": registry.UpdatedAt.Format(time.RFC3339),
+	})
+
+	return registry, nil
+}
+
+// filterBackups categorizes backups based on retention policies.
+func (o *Operation) filterBackups(ctx context.Context, reg *registry.Registry) ([]registry.BackupEntry, error) {
+	o.logger.Info(ctx, "Stage 2: Filter backups")
+	start := time.Now()
+	defer func() {
+		duration := time.Since(start)
+		o.logger.Info(ctx, "Stage 2 completed", logging.Fields{
+			"duration": duration.String(),
+		})
+	}()
+
+	// Filter only ready backups
+	var readyBackups []registry.BackupEntry
+	for _, backup := range reg.Backups {
+		if backup.Status == registry.StatusReady {
+			readyBackups = append(readyBackups, backup)
+		}
+	}
+
+	o.logger.Debug(ctx, "Filtered ready backups", logging.Fields{
+		"total_backups": len(reg.Backups),
+		"ready_backups": len(readyBackups),
+	})
+
+	return readyBackups, nil
+}
+
+// applyRetentionPolicies determines which backups to keep or delete.
+func (o *Operation) applyRetentionPolicies(
+	ctx context.Context,
+	backups []registry.BackupEntry,
+) ([]registry.BackupEntry, error) {
+	o.logger.Info(ctx, "Stage 3: Apply retention policies")
+	start := time.Now()
+	defer func() {
+		duration := time.Since(start)
+		o.logger.Info(ctx, "Stage 3 completed", logging.Fields{
+			"duration": duration.String(),
+		})
+	}()
+
+	// Apply all policies against the original backups slice to create union of kept items
+	keepSet := make(map[string]bool) // Union of all items to keep
+
+	// Apply MaxCount policy
+	if o.config.MaxCount > 0 {
+		keep, remove := o.applyMaxCountPolicy(ctx, backups)
+
+		o.logger.Debug(ctx, "Applied MaxCount policy", logging.Fields{
+			"keep_count":   len(keep),
+			"remove_count": len(remove),
+			"max_count":    o.config.MaxCount,
+		})
+
+		// Add items to keep set
+		for _, backup := range keep {
+			keepSet[backup.ID] = true
+		}
+	}
+
+	// Apply MaxAge policy
+	if o.config.MaxAge > 0 {
+		keep, remove := o.applyMaxAgePolicy(ctx, backups)
+
+		o.logger.Debug(ctx, "Applied MaxAge policy", logging.Fields{
+			"keep_count":   len(keep),
+			"remove_count": len(remove),
+			"max_age":      o.config.MaxAge.String(),
+		})
+
+		// Add items to keep set
+		for _, backup := range keep {
+			keepSet[backup.ID] = true
+		}
+	}
+
+	// Apply periodic policies (daily, weekly, monthly)
+	if o.config.KeepDaily > 0 || o.config.KeepWeekly > 0 || o.config.KeepMonthly > 0 {
+		keep, remove := o.applyPeriodicPolicies(ctx, backups)
+
+		o.logger.Debug(ctx, "Applied periodic policies", logging.Fields{
+			"keep_count":   len(keep),
+			"remove_count": len(remove),
+			"keep_daily":   o.config.KeepDaily,
+			"keep_weekly":  o.config.KeepWeekly,
+			"keep_monthly": o.config.KeepMonthly,
+		})
+
+		// Add items to keep set
+		for _, backup := range keep {
+			keepSet[backup.ID] = true
+		}
+	}
+
+	// Build final keep and remove lists from the union set
+	var finalKeep []registry.BackupEntry
+	var finalRemove []registry.BackupEntry
+
+	for _, backup := range backups {
+		if keepSet[backup.ID] {
+			finalKeep = append(finalKeep, backup)
+		} else {
+			finalRemove = append(finalRemove, backup)
+		}
+	}
+
+	o.logger.Info(ctx, "Retention policy application completed", logging.Fields{
+		"total_backups": len(finalKeep) + len(finalRemove),
+		"keep_count":    len(finalKeep),
+		"remove_count":  len(finalRemove),
+	})
+
+	return finalRemove, nil
+}
+
+// executeRetentionActions performs the actual deletion operations.
+func (o *Operation) executeRetentionActions(
+	ctx context.Context,
+	backupsToRemove []registry.BackupEntry,
+) ([]registry.BackupEntry, error) {
+	o.logger.Info(ctx, "Stage 4: Execute retention actions")
+	start := time.Now()
+	defer func() {
+		duration := time.Since(start)
+		o.logger.Info(ctx, "Stage 4 completed", logging.Fields{
+			"duration": duration.String(),
+		})
+	}()
+
+	// Log summary of retention decisions
+	o.logger.Info(ctx, "Retention summary", logging.Fields{
+		"remove_count": len(backupsToRemove),
+		"dry_run":      o.config.DryRun,
+	})
+
+	// Log details for each backup being removed
+	for _, backup := range backupsToRemove {
+		if o.config.DryRun {
+			o.logger.Info(ctx, "Dry run: would remove backup", logging.Fields{
+				"filename":   backup.Filename,
+				"created_at": backup.CreatedAt.Format(time.RFC3339),
+				"size_bytes": backup.SizeBytes,
+				"status":     backup.Status,
+			})
+		} else {
+			o.logger.Info(ctx, "Removing backup", logging.Fields{
+				"filename":   backup.Filename,
+				"created_at": backup.CreatedAt.Format(time.RFC3339),
+				"size_bytes": backup.SizeBytes,
+				"status":     backup.Status,
+			})
+		}
+	}
+
+	// Delete backup files
+	var successfullyDeleted []registry.BackupEntry
+	for _, backup := range backupsToRemove {
+		if err := o.deleteBackup(ctx, backup); err != nil {
+			if !o.config.Force {
+				return nil, err
+			}
+			// In force mode, log error but continue
+			o.logger.Error(ctx, "Failed to delete backup but continuing due to force mode", err, logging.Fields{
+				"filename": backup.Filename,
+			})
+		} else {
+			// Only add to successfullyDeleted if deleteBackup returned nil
+			successfullyDeleted = append(successfullyDeleted, backup)
+		}
+	}
+
+	if o.config.DryRun {
+		return nil, nil
+	}
+
+	return successfullyDeleted, nil
+}
+
+// updateRegistry saves the updated registry after retention operations.
+func (o *Operation) updateRegistry(ctx context.Context, backupsToRemove []registry.BackupEntry) error {
+	o.logger.Info(ctx, "Stage 5: Update registry")
+	start := time.Now()
+	defer func() {
+		duration := time.Since(start)
+		o.logger.Info(ctx, "Stage 5 completed", logging.Fields{
+			"duration": duration.String(),
+		})
+	}()
+
+	// Mark successfully deleted backups as deleted in the registry
+	var successfullyMarked []registry.BackupEntry
+	for _, backup := range backupsToRemove {
+		if err := o.registrySvc.MarkDeleted(ctx, backup.ID); err != nil {
+			o.logger.Error(ctx, "Failed to mark backup as deleted", err, logging.Fields{
+				"backup_id": backup.ID,
+				"filename":  backup.Filename,
+				"error":     err.Error(),
+			})
+
+			if !o.config.Force {
+				return fmt.Errorf(
+					"%w: failed to mark backup %s as deleted: %w",
+					ErrRegistryUpdateFailed,
+					backup.Filename,
+					err,
+				)
+			}
+
+			o.logger.Warn(ctx, "Continuing despite registry update failure due to force mode", logging.Fields{
+				"backup_id": backup.ID,
+				"filename":  backup.Filename,
+			})
+		} else {
+			// Only add to successfullyMarked if MarkDeleted returned nil
+			successfullyMarked = append(successfullyMarked, backup)
+		}
+	}
+
+	o.logger.Debug(ctx, "Registry updated", logging.Fields{
+		"removed_count": len(successfullyMarked),
+	})
+
+	return nil
+}
+
+// applyMaxCountPolicy applies the maximum count retention policy.
+func (o *Operation) applyMaxCountPolicy(
+	_ context.Context,
+	backups []registry.BackupEntry,
+) ([]registry.BackupEntry, []registry.BackupEntry) {
+	if o.config.MaxCount == 0 {
+		return backups, nil // No limit
+	}
+
+	if len(backups) <= o.config.MaxCount {
+		return backups, nil // Under limit
+	}
+
+	// Sort by creation time (newest first)
+	sorted := make([]registry.BackupEntry, len(backups))
+	copy(sorted, backups)
+
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].CreatedAt.After(sorted[j].CreatedAt)
+	})
+
+	// Keep first MaxCount backups
+	keep := sorted[:o.config.MaxCount]
+	remove := sorted[o.config.MaxCount:]
+
+	return keep, remove
+}
+
+// applyMaxAgePolicy applies the maximum age retention policy.
+func (o *Operation) applyMaxAgePolicy(
+	_ context.Context,
+	backups []registry.BackupEntry,
+) ([]registry.BackupEntry, []registry.BackupEntry) {
+	if o.config.MaxAge == 0 {
+		return backups, nil // No age limit
+	}
+
+	now := time.Now()
+	cutoff := now.Add(-o.config.MaxAge)
+
+	var keep, remove []registry.BackupEntry
+
+	for _, backup := range backups {
+		if backup.CreatedAt.After(cutoff) {
+			keep = append(keep, backup)
+		} else {
+			remove = append(remove, backup)
+		}
+	}
+
+	return keep, remove
+}
+
+// applyPeriodicPolicies applies daily, weekly, and monthly retention policies.
+func (o *Operation) applyPeriodicPolicies(
+	ctx context.Context,
+	backups []registry.BackupEntry,
+) ([]registry.BackupEntry, []registry.BackupEntry) {
+	var keep, remove []registry.BackupEntry
+
+	// Create a map to track which backups to keep
+	keepMap := make(map[string]bool)
+
+	// Apply daily policy
+	if o.config.KeepDaily > 0 {
+		dailyKeep := o.selectPeriodBackups(
+			ctx,
+			backups,
+			func(backup registry.BackupEntry) string { return backup.CreatedAt.Format("2006-01-02") },
+			o.config.KeepDaily,
+		)
+
+		for _, backup := range dailyKeep {
+			keepMap[backup.ID] = true
+		}
+	}
+
+	// Apply weekly policy
+	if o.config.KeepWeekly > 0 {
+		weeklyKeep := o.selectPeriodBackups(ctx, backups, func(backup registry.BackupEntry) string {
+			year, week := backup.CreatedAt.ISOWeek()
+			return fmt.Sprintf("%d-W%02d", year, week)
+		}, o.config.KeepWeekly)
+
+		for _, backup := range weeklyKeep {
+			keepMap[backup.ID] = true
+		}
+	}
+
+	// Apply monthly policy
+	if o.config.KeepMonthly > 0 {
+		monthlyKeep := o.selectPeriodBackups(
+			ctx,
+			backups,
+			func(backup registry.BackupEntry) string { return backup.CreatedAt.Format("2006-01") },
+			o.config.KeepMonthly,
+		)
+		for _, backup := range monthlyKeep {
+			keepMap[backup.ID] = true
+		}
+	}
+
+	// Separate keep and remove based on the keepMap
+	for _, backup := range backups {
+		if keepMap[backup.ID] {
+			keep = append(keep, backup)
+		} else {
+			remove = append(remove, backup)
+		}
+	}
+
+	return keep, remove
+}
+
+// selectPeriodBackups selects the most recent backups for a given period.
+func (o *Operation) selectPeriodBackups(
+	_ context.Context,
+	backups []registry.BackupEntry,
+	groupFn func(backup registry.BackupEntry) string,
+	count int,
+) []registry.BackupEntry {
+	// Group backups by day
+	groups := make(map[string][]registry.BackupEntry)
+
+	for _, backup := range backups {
+		groupKey := groupFn(backup)
+		groups[groupKey] = append(groups[groupKey], backup)
+	}
+
+	// For each day, select the most recent backup
+	var selected []registry.BackupEntry
+	for _, group := range groups {
+		// Sort by creation time (newest first)
+		sort.Slice(group, func(i, j int) bool {
+			return group[i].CreatedAt.After(group[j].CreatedAt)
+		})
+
+		// Take the most recent backup for this day
+		if len(group) > 0 {
+			selected = append(selected, group[0])
+		}
+	}
+
+	// Sort all selected backups by creation time (newest first)
+	sort.Slice(selected, func(i, j int) bool {
+		return selected[i].CreatedAt.After(selected[j].CreatedAt)
+	})
+
+	// Limit to the requested count
+	if len(selected) > count {
+		selected = selected[:count]
+	}
+
+	return selected
+}
+
+// deleteBackup deletes a backup file from storage.
+func (o *Operation) deleteBackup(ctx context.Context, backup registry.BackupEntry) error {
+	if o.config.DryRun {
+		o.logger.Info(ctx, "Dry run: would delete backup", logging.Fields{
+			"filename":   backup.Filename,
+			"created_at": backup.CreatedAt.Format(time.RFC3339),
+			"size_bytes": backup.SizeBytes,
+		})
+		return nil
+	}
+
+	o.logger.Info(ctx, "Deleting backup", logging.Fields{
+		"filename":   backup.Filename,
+		"created_at": backup.CreatedAt.Format(time.RFC3339),
+		"size_bytes": backup.SizeBytes,
+	})
+
+	if err := o.storage.Delete(ctx, backup.Filename); err != nil {
+		o.logger.Error(ctx, "Failed to delete backup file", err, logging.Fields{
+			"filename": backup.Filename,
+			"error":    err.Error(),
+		})
+
+		return fmt.Errorf("%w: failed to delete backup %s: %w", ErrBackupDeleteFailed, backup.Filename, err)
+	}
+
+	return nil
+}

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -4,4 +4,5 @@ import "errors"
 
 var (
 	ErrInvalidArgument = errors.New("invalid argument")
+	ErrNotFound        = errors.New("object not found")
 )

--- a/internal/storage/filesystem.go
+++ b/internal/storage/filesystem.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -8,7 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"sort"
+	"strings"
 )
 
 type filesystemStorage struct {
@@ -32,8 +33,12 @@ func (f *filesystemStorage) Upload(ctx context.Context, filename string, data io
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 
-	fullPath := filepath.Join(f.basePath, filename)
-	file, err := os.OpenFile(fullPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	fullPath, err := f.makePath(filename)
+	if err != nil {
+		return err
+	}
+
+	file, err := os.CreateTemp(f.basePath, filename)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)
 	}
@@ -42,25 +47,35 @@ func (f *filesystemStorage) Upload(ctx context.Context, filename string, data io
 			err = errors.Join(err, fmt.Errorf("failed to close file: %w", closeErr))
 		}
 		if err != nil {
-			if rmErr := os.Remove(fullPath); rmErr != nil {
+			if rmErr := os.Remove(file.Name()); rmErr != nil {
 				err = errors.Join(err, fmt.Errorf("failed to remove partial file: %w", rmErr))
 			}
 		}
 	}()
 
 	// Use context-aware copying for cancellation support
-	if cpyErr := copyWithContext(ctx, file, data); cpyErr != nil {
-		err = fmt.Errorf("failed to write file: %w", cpyErr)
+	if err = copyWithContext(ctx, file, data); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
 	}
 
-	return err
+	if err = os.Rename(file.Name(), fullPath); err != nil {
+		return fmt.Errorf("failed to rename file: %w", err)
+	}
+
+	return nil
 }
 
 func (f *filesystemStorage) Download(ctx context.Context, path string, data io.Writer) (err error) {
-	fullPath := filepath.Join(f.basePath, path)
+	fullPath, err := f.makePath(path)
+	if err != nil {
+		return err
+	}
 
 	file, err := os.Open(fullPath)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("failed to open file: %w", ErrNotFound)
+		}
 		return fmt.Errorf("failed to open file: %w", err)
 	}
 
@@ -78,57 +93,75 @@ func (f *filesystemStorage) Download(ctx context.Context, path string, data io.W
 	return err
 }
 
-func (f *filesystemStorage) DeleteOldBackups(ctx context.Context, maxCount int) error {
-	if maxCount == 0 {
-		return nil
+func (f *filesystemStorage) UploadBytes(ctx context.Context, filename string, data []byte) error {
+	return f.Upload(ctx, filename, bytes.NewReader(data))
+}
+
+func (f *filesystemStorage) DownloadBytes(ctx context.Context, filename string) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := f.Download(ctx, filename, &buf); err != nil {
+		return nil, err
 	}
 
-	fullPath := f.basePath
+	return buf.Bytes(), nil
+}
 
-	// Read directory
-	entries, err := os.ReadDir(fullPath)
+func (f *filesystemStorage) Delete(ctx context.Context, filename string) error {
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("filesystem: %w", ctx.Err())
+	default:
+	}
+
+	fullPath, err := f.makePath(filename)
+	if err != nil {
+		return err
+	}
+
+	if rmErr := os.Remove(fullPath); rmErr != nil {
+		if os.IsNotExist(rmErr) {
+			return fmt.Errorf("failed to delete file: %w", ErrNotFound)
+		}
+		return fmt.Errorf("failed to delete file: %w", rmErr)
+	}
+
+	return nil
+}
+
+func (f *filesystemStorage) List(ctx context.Context) ([]string, error) {
+	entries, err := os.ReadDir(f.basePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil // Directory doesn't exist, nothing to delete
+			return []string{}, nil
 		}
-		return fmt.Errorf("failed to read directory: %w", err)
+		return nil, fmt.Errorf("failed to read directory: %w", err)
 	}
 
-	// Filter for files only
-	files := make([]os.DirEntry, 0)
+	files := make([]string, 0, len(entries))
 	for _, entry := range entries {
-		if !entry.IsDir() {
-			files = append(files, entry)
-		}
-	}
-
-	if len(files) <= maxCount {
-		return nil
-	}
-
-	// Sort files by name (oldest first) - filenames contain sortable timestamps
-	sort.Slice(files, func(i, j int) bool {
-		return files[i].Name() < files[j].Name()
-	})
-
-	// Delete oldest files
-	errs := make([]error, 0)
-	toDelete := files[:len(files)-maxCount]
-	for _, file := range toDelete {
-		// Check for context cancellation
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("filesystem: %w", ctx.Err())
+			return nil, fmt.Errorf("filesystem: %w", ctx.Err())
 		default:
 		}
 
-		filePath := filepath.Join(fullPath, file.Name())
-		if delErr := os.Remove(filePath); delErr != nil {
-			errs = append(errs, fmt.Errorf("failed to delete file %s: %w", file.Name(), delErr))
+		if entry.IsDir() {
+			continue
 		}
+		files = append(files, entry.Name())
 	}
 
-	return errors.Join(errs...)
+	return files, nil
+}
+
+func (f *filesystemStorage) makePath(filename string) (string, error) {
+	cleanRel := strings.TrimPrefix(filepath.Clean(string(filepath.Separator)+filename), string(filepath.Separator))
+	fullPath := filepath.Join(f.basePath, cleanRel)
+	rel, err := filepath.Rel(f.basePath, fullPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w: invalid filename", ErrInvalidArgument)
+	}
+	return fullPath, nil
 }
 
 // copyWithContext performs io.Copy with context cancellation support.

--- a/internal/storage/filesystem.go
+++ b/internal/storage/filesystem.go
@@ -38,7 +38,7 @@ func (f *filesystemStorage) Upload(ctx context.Context, filename string, data io
 		return err
 	}
 
-	file, err := os.CreateTemp(f.basePath, filename)
+	file, err := os.CreateTemp(f.basePath, filepath.Base(filename))
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)
 	}
@@ -189,4 +189,10 @@ func copyWithContext(ctx context.Context, dst io.Writer, src io.Reader) error {
 			}
 		}
 	}
+}
+
+// Close closes the filesystem storage backend.
+// For filesystem storage, this is a no-op as no persistent connections are held.
+func (f *filesystemStorage) Close() error {
+	return nil
 }

--- a/internal/storage/ftp.go
+++ b/internal/storage/ftp.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -8,7 +9,6 @@ import (
 	"net"
 	"net/url"
 	"path"
-	"sort"
 	"strings"
 
 	"github.com/secsy/goftp"
@@ -123,48 +123,66 @@ func (f *ftpStorage) Download(ctx context.Context, filename string, data io.Writ
 	// Download file
 	err := f.client.Retrieve(remotePath, data)
 	if err != nil {
+		if isFTPNotFoundError(err) {
+			return fmt.Errorf("failed to download file: %w", ErrNotFound)
+		}
 		return fmt.Errorf("failed to download file: %w", err)
 	}
 
 	return nil
 }
 
-func (f *ftpStorage) DeleteOldBackups(ctx context.Context, maxCount int) error {
-	if maxCount == 0 {
-		return nil
+func (f *ftpStorage) UploadBytes(ctx context.Context, relPath string, data []byte) error {
+	return f.Upload(ctx, relPath, bytes.NewReader(data))
+}
+
+func (f *ftpStorage) DownloadBytes(ctx context.Context, filename string) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := f.Download(ctx, filename, &buf); err != nil {
+		return nil, err
 	}
 
-	// List files in remote directory
-	files, err := f.listRemoteFiles(f.basePath)
-	if err != nil {
-		return fmt.Errorf("failed to remove old backups: %w", err)
+	return buf.Bytes(), nil
+}
+
+func (f *ftpStorage) Delete(ctx context.Context, filename string) error {
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("context canceled: %w", ctx.Err())
+	default:
 	}
 
-	if len(files) <= maxCount {
-		return nil
-	}
-
-	// Sort files by name (which includes timestamp) to delete oldest
-	sort.Strings(files)
-
-	// Delete oldest files
-	errs := make([]error, 0)
-	toDelete := files[:len(files)-maxCount]
-	for _, file := range toDelete {
-		// Check for context cancellation
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("context canceled: %w", ctx.Err())
-		default:
+	cleanRel := strings.TrimPrefix(path.Clean("/"+filename), "/")
+	remotePath := path.Join(f.basePath, cleanRel)
+	if err := f.client.Delete(remotePath); err != nil {
+		if isFTPNotFoundError(err) {
+			return fmt.Errorf("failed to delete file: %w", ErrNotFound)
 		}
-
-		remotePath := path.Join(f.basePath, file)
-		if delErr := f.client.Delete(remotePath); delErr != nil {
-			errs = append(errs, fmt.Errorf("failed to delete file %s: %w", file, delErr))
-		}
+		return fmt.Errorf("failed to delete file: %w", err)
 	}
 
-	return errors.Join(errs...)
+	return nil
+}
+
+func (f *ftpStorage) List(ctx context.Context) ([]string, error) {
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("context canceled: %w", ctx.Err())
+	default:
+	}
+
+	return f.listRemoteFiles(f.basePath)
+}
+
+// Close closes the FTP connection.
+func (f *ftpStorage) Close() error {
+	if f.client != nil {
+		if err := f.client.Close(); err != nil {
+			return fmt.Errorf("failed to close FTP connection: %w", err)
+		}
+		f.client = nil
+	}
+	return nil
 }
 
 // ensureRemoteDir ensures that a remote directory exists, creating it if necessary.
@@ -213,13 +231,7 @@ func (f *ftpStorage) listRemoteFiles(dir string) ([]string, error) {
 	return fileNames, nil
 }
 
-// Close closes the FTP connection.
-func (f *ftpStorage) Close() error {
-	if f.client != nil {
-		if err := f.client.Close(); err != nil {
-			return fmt.Errorf("failed to close FTP connection: %w", err)
-		}
-		f.client = nil
-	}
-	return nil
+func isFTPNotFoundError(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "550") || strings.Contains(msg, "not found")
 }

--- a/internal/storage/ftp.go
+++ b/internal/storage/ftp.go
@@ -14,6 +14,43 @@ import (
 	"github.com/secsy/goftp"
 )
 
+// validateFilename checks if the filename is valid (not empty, not absolute, no path traversal).
+// It returns a cleaned relative path or an error if the path is invalid or escapes basePath.
+func (f *ftpStorage) validateFilename(filename string) (string, error) {
+	if filename == "" {
+		return "", fmt.Errorf("%w: filename cannot be empty", ErrInvalidArgument)
+	}
+
+	// Reject absolute paths
+	if path.IsAbs(filename) {
+		return "", fmt.Errorf("%w: filename cannot be absolute", ErrInvalidArgument)
+	}
+
+	// Clean the path and ensure it's relative
+	cleanRel := strings.TrimPrefix(path.Clean("/"+filename), "/")
+
+	// Check for path traversal attempts - if after cleaning the path still contains "..",
+	// it indicates an escape attempt
+	if strings.HasPrefix(cleanRel, "..") || strings.Contains(cleanRel, "/../") {
+		return "", fmt.Errorf("%w: filename contains path traversal", ErrInvalidArgument)
+	}
+
+	// Compute the full remote path
+	remotePath := path.Join(f.basePath, cleanRel)
+
+	// Verify the resulting path is still within basePath by checking prefix
+	// We need to ensure basePath ends with "/" for proper prefix checking
+	basePrefix := f.basePath
+	if !strings.HasSuffix(basePrefix, "/") {
+		basePrefix += "/"
+	}
+	if !strings.HasPrefix(remotePath+"/", basePrefix) && remotePath != f.basePath {
+		return "", fmt.Errorf("%w: filename escapes base path", ErrInvalidArgument)
+	}
+
+	return cleanRel, nil
+}
+
 var (
 	ErrFTPHostRequired = errors.New("FTP storage requires host")
 )
@@ -76,13 +113,17 @@ func NewFTPStorage(u *url.URL) (Backend, error) {
 	}, nil
 }
 
-func (f *ftpStorage) Upload(ctx context.Context, relPath string, data io.Reader) error {
-	// Create full remote path
-	remotePath := path.Join(f.basePath, relPath)
+func (f *ftpStorage) Upload(ctx context.Context, filename string, data io.Reader) error {
+	// Validate filename
+	cleanRel, err := f.validateFilename(filename)
+	if err != nil {
+		return err
+	}
+	remotePath := path.Join(f.basePath, cleanRel)
 
 	// Ensure remote directory exists
-	if err := f.ensureRemoteDir(path.Dir(remotePath)); err != nil {
-		return fmt.Errorf("failed to ensure remote directory: %w", err)
+	if dirErr := f.ensureRemoteDir(path.Dir(remotePath)); dirErr != nil {
+		return fmt.Errorf("failed to ensure remote directory: %w", dirErr)
 	}
 
 	// Fail fast if already canceled
@@ -94,23 +135,26 @@ func (f *ftpStorage) Upload(ctx context.Context, relPath string, data io.Reader)
 
 	// Upload file
 	tmpPath := remotePath + ".tmp"
-	if err := f.client.Store(tmpPath, data); err != nil {
-		return fmt.Errorf("failed to upload file: %w", err)
+	if stErr := f.client.Store(tmpPath, data); stErr != nil {
+		return fmt.Errorf("failed to upload file: %w", stErr)
 	}
 
-	if err := f.client.Rename(tmpPath, remotePath); err != nil {
+	if rnErr := f.client.Rename(tmpPath, remotePath); rnErr != nil {
 		if delErr := f.client.Delete(tmpPath); delErr != nil {
-			return fmt.Errorf("failed to rename file and delete temporary file: %w", errors.Join(err, delErr))
+			return fmt.Errorf("failed to rename file and delete temporary file: %w", errors.Join(rnErr, delErr))
 		}
-		return fmt.Errorf("failed to rename file: %w", err)
+		return fmt.Errorf("failed to rename file: %w", rnErr)
 	}
 
 	return nil
 }
 
 func (f *ftpStorage) Download(ctx context.Context, filename string, data io.Writer) error {
-	// Create full remote path (prevent escaping basePath)
-	cleanRel := strings.TrimPrefix(path.Clean("/"+filename), "/")
+	// Validate filename
+	cleanRel, err := f.validateFilename(filename)
+	if err != nil {
+		return err
+	}
 	remotePath := path.Join(f.basePath, cleanRel)
 
 	// Fail fast if already canceled
@@ -121,7 +165,7 @@ func (f *ftpStorage) Download(ctx context.Context, filename string, data io.Writ
 	}
 
 	// Download file
-	err := f.client.Retrieve(remotePath, data)
+	err = f.client.Retrieve(remotePath, data)
 	if err != nil {
 		if isFTPNotFoundError(err) {
 			return fmt.Errorf("failed to download file: %w", ErrNotFound)
@@ -132,8 +176,8 @@ func (f *ftpStorage) Download(ctx context.Context, filename string, data io.Writ
 	return nil
 }
 
-func (f *ftpStorage) UploadBytes(ctx context.Context, relPath string, data []byte) error {
-	return f.Upload(ctx, relPath, bytes.NewReader(data))
+func (f *ftpStorage) UploadBytes(ctx context.Context, filename string, data []byte) error {
+	return f.Upload(ctx, filename, bytes.NewReader(data))
 }
 
 func (f *ftpStorage) DownloadBytes(ctx context.Context, filename string) ([]byte, error) {
@@ -146,19 +190,24 @@ func (f *ftpStorage) DownloadBytes(ctx context.Context, filename string) ([]byte
 }
 
 func (f *ftpStorage) Delete(ctx context.Context, filename string) error {
+	// Validate filename
+	cleanRel, err := f.validateFilename(filename)
+	if err != nil {
+		return err
+	}
+	remotePath := path.Join(f.basePath, cleanRel)
+
 	select {
 	case <-ctx.Done():
 		return fmt.Errorf("context canceled: %w", ctx.Err())
 	default:
 	}
 
-	cleanRel := strings.TrimPrefix(path.Clean("/"+filename), "/")
-	remotePath := path.Join(f.basePath, cleanRel)
-	if err := f.client.Delete(remotePath); err != nil {
-		if isFTPNotFoundError(err) {
+	if delErr := f.client.Delete(remotePath); delErr != nil {
+		if isFTPNotFoundError(delErr) {
 			return fmt.Errorf("failed to delete file: %w", ErrNotFound)
 		}
-		return fmt.Errorf("failed to delete file: %w", err)
+		return fmt.Errorf("failed to delete file: %w", delErr)
 	}
 
 	return nil
@@ -231,7 +280,34 @@ func (f *ftpStorage) listRemoteFiles(dir string) ([]string, error) {
 	return fileNames, nil
 }
 
+// isFTPNotFoundError checks if the error is a true "file not found" error.
+// It inspects both the FTP error code and the message content to distinguish
+// between file not found errors and permission/authentication errors.
+// Only returns true when the error explicitly indicates a missing file
+// (e.g., contains phrases like "No such file", "file not found", "not found").
 func isFTPNotFoundError(err error) bool {
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "550") || strings.Contains(msg, "not found")
+	var ftpErr goftp.Error
+
+	if !errors.As(err, &ftpErr) || ftpErr.Code() != 550 {
+		return false
+	}
+
+	msg := strings.ToLower(ftpErr.Message())
+
+	// Check for clear "file not found" indicators
+	notFoundIndicators := []string{
+		"no such file",
+		"file not found",
+		"not found",
+		"does not exist",
+		"cannot find",
+	}
+
+	for _, indicator := range notFoundIndicators {
+		if strings.Contains(msg, indicator) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -195,3 +195,9 @@ func (s *s3Storage) List(ctx context.Context) ([]string, error) {
 
 	return files, nil
 }
+
+// Close closes the S3 storage backend.
+// For S3, this is a no-op as the AWS SDK client doesn't require explicit cleanup.
+func (s *s3Storage) Close() error {
+	return nil
+}

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -1,11 +1,14 @@
 package storage
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/url"
-	"sort"
+	"path"
 	"strconv"
 	"strings"
 
@@ -93,8 +96,14 @@ func NewS3Storage(u *url.URL) (Backend, error) {
 	}, nil
 }
 
-func (s *s3Storage) Upload(ctx context.Context, path string, data io.Reader) error {
-	key := s.prefix + strings.TrimPrefix(path, "/")
+func (s *s3Storage) Upload(ctx context.Context, p string, data io.Reader) error {
+	key := s.prefix + strings.TrimPrefix(p, "/")
+
+	extension := path.Ext(p)
+	contentType := mime.TypeByExtension(extension)
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
 
 	uploader := manager.NewUploader(s.client, func(u *manager.Uploader) {
 		u.PartSize = s.partSize
@@ -102,7 +111,7 @@ func (s *s3Storage) Upload(ctx context.Context, path string, data io.Reader) err
 	_, err := uploader.Upload(ctx, &s3.PutObjectInput{
 		Bucket:      aws.String(s.bucket),
 		Key:         aws.String(key),
-		ContentType: aws.String("application/gzip"),
+		ContentType: &contentType,
 		Body:        data,
 	})
 	if err != nil {
@@ -121,6 +130,10 @@ func (s *s3Storage) Download(ctx context.Context, path string, data io.Writer) e
 		Key:    aws.String(key),
 	})
 	if err != nil {
+		var noSuchKey *types.NoSuchKey
+		if errors.As(err, &noSuchKey) {
+			return fmt.Errorf("failed to get object from S3: %w", ErrNotFound)
+		}
 		return fmt.Errorf("failed to get object from S3: %w", err)
 	}
 	defer func() {
@@ -135,54 +148,50 @@ func (s *s3Storage) Download(ctx context.Context, path string, data io.Writer) e
 	return nil
 }
 
-func (s *s3Storage) DeleteOldBackups(ctx context.Context, maxCount int) error {
-	if maxCount == 0 {
-		return nil
-	}
-	if maxCount < 0 {
-		return fmt.Errorf("%w: maxCount must be >= 0", ErrInvalidArgument)
+func (s *s3Storage) UploadBytes(ctx context.Context, path string, data []byte) error {
+	return s.Upload(ctx, path, bytes.NewReader(data))
+}
+
+func (s *s3Storage) DownloadBytes(ctx context.Context, path string) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := s.Download(ctx, path, &buf); err != nil {
+		return nil, err
 	}
 
-	var err error
-	var output *s3.ListObjectsV2Output
+	return buf.Bytes(), nil
+}
+
+func (s *s3Storage) Delete(ctx context.Context, path string) error {
+	key := s.prefix + strings.TrimPrefix(path, "/")
+	_, err := s.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete object: %w", err)
+	}
+
+	return nil
+}
+
+func (s *s3Storage) List(ctx context.Context) ([]string, error) {
 	input := &s3.ListObjectsV2Input{
 		Bucket: aws.String(s.bucket),
 		Prefix: aws.String(s.prefix),
 	}
-	objects := make([]types.ObjectIdentifier, 0, maxCount+1)
-	objectPaginator := s3.NewListObjectsV2Paginator(s.client, input)
-	for objectPaginator.HasMorePages() {
-		output, err = objectPaginator.NextPage(ctx)
+
+	files := make([]string, 0)
+	p := s3.NewListObjectsV2Paginator(s.client, input)
+	for p.HasMorePages() {
+		out, err := p.NextPage(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to list objects: %w", err)
+			return nil, fmt.Errorf("failed to list objects: %w", err)
 		}
-		for _, obj := range output.Contents {
-			objects = append(objects, types.ObjectIdentifier{
-				Key: obj.Key,
-			})
+		for _, obj := range out.Contents {
+			key := aws.ToString(obj.Key)
+			files = append(files, strings.TrimPrefix(key, s.prefix))
 		}
 	}
 
-	if len(objects) <= maxCount {
-		return nil
-	}
-
-	sort.Slice(objects, func(i, j int) bool {
-		return aws.ToString(objects[i].Key) < aws.ToString(objects[j].Key)
-	})
-
-	toDelete := objects[:len(objects)-maxCount]
-
-	_, err = s.client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
-		Bucket: aws.String(s.bucket),
-		Delete: &types.Delete{
-			Objects: toDelete,
-			Quiet:   aws.Bool(true),
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("failed to delete objects: %w", err)
-	}
-
-	return nil
+	return files, nil
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -24,4 +24,8 @@ type Backend interface {
 
 	// DownloadBytes downloads a small object from the backend into memory.
 	DownloadBytes(ctx context.Context, filename string) ([]byte, error)
+
+	// Close closes the storage backend and releases any resources.
+	// Implementations that don't require cleanup should return nil.
+	Close() error
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -13,6 +13,15 @@ type Backend interface {
 	// Download downloads data from the specified path in the storage backend
 	Download(ctx context.Context, filename string, data io.Writer) error
 
-	// DeleteOldBackups removes old backups based on the retention policy
-	DeleteOldBackups(ctx context.Context, maxCount int) error
+	// Delete removes a single object from the storage backend.
+	Delete(ctx context.Context, filename string) error
+
+	// List returns filenames available in the current backend prefix/path.
+	List(ctx context.Context) ([]string, error)
+
+	// UploadBytes uploads a small in-memory object to the backend.
+	UploadBytes(ctx context.Context, filename string, data []byte) error
+
+	// DownloadBytes downloads a small object from the backend into memory.
+	DownloadBytes(ctx context.Context, filename string) ([]byte, error)
 }

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/capcom6/mariadb-backup-s3/internal/cli/commands/backup"
 	"github.com/capcom6/mariadb-backup-s3/internal/cli/commands/restore"
+	"github.com/capcom6/mariadb-backup-s3/internal/cli/commands/retention"
 	"github.com/capcom6/mariadb-backup-s3/internal/core/codes"
 	"github.com/capcom6/mariadb-backup-s3/internal/logging"
 	"github.com/joho/godotenv"
@@ -56,6 +57,7 @@ func main() {
 		Commands: []*cli.Command{
 			backup.Command(),
 			restore.Command(),
+			retention.Command(),
 		},
 		Before: func(ctx context.Context, _ *cli.Command) (context.Context, error) {
 			logger.Info(ctx, "Starting MariaDB Backup S3 application")

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 
 	"github.com/capcom6/mariadb-backup-s3/internal/cli/commands/backup"
+	"github.com/capcom6/mariadb-backup-s3/internal/cli/commands/registry"
 	"github.com/capcom6/mariadb-backup-s3/internal/cli/commands/restore"
 	"github.com/capcom6/mariadb-backup-s3/internal/cli/commands/retention"
 	"github.com/capcom6/mariadb-backup-s3/internal/core/codes"
@@ -58,6 +59,7 @@ func main() {
 			backup.Command(),
 			restore.Command(),
 			retention.Command(),
+			registry.Command(),
 		},
 		Before: func(ctx context.Context, _ *cli.Command) (context.Context, error) {
 			logger.Info(ctx, "Starting MariaDB Backup S3 application")

--- a/pkg/counting/writer.go
+++ b/pkg/counting/writer.go
@@ -1,0 +1,21 @@
+package counting
+
+import "sync/atomic"
+
+type Writer struct {
+	n atomic.Int64
+}
+
+func NewWriter() *Writer {
+	return new(Writer)
+}
+
+func (c *Writer) Write(p []byte) (int, error) {
+	n := len(p)
+	c.n.Add(int64(n))
+	return n, nil
+}
+
+func (c *Writer) N() int64 {
+	return c.n.Load()
+}


### PR DESCRIPTION
### Motivation

- Introduce a first-class backups registry to record structured metadata for each successful backup so restore and retention logic can rely on metadata instead of filename heuristics. 
- Improve retention correctness and restore UX by using the registry as the source of truth and enabling selection by latest or registry ID. 
- Provide a migration/fallback path to rebuild a registry from object listings when no registry is present. 

### Description

- Add a new `internal/registry` package implementing registry model, parsing, validation, store helpers, and constants (`.backup-registry.json`, statuses, sort/validate helpers). 
- Extend the storage abstraction with `Delete`, `List`, `UploadBytes`, and `DownloadBytes` and add `ErrNotFound`; update `filesystem`, `s3`, and `ftp` backends with corresponding implementations and small error mapping. 
- Enhance backup pipeline: compute SHA256 and size while uploading, upsert a `BackupEntry` into the registry, and apply registry-driven retention (with rebuild-from-listing fallback); factor `newStorageBackend` for test injection. 
- Add CLI features: `backup list` command to print registry entries and `restore` selection flags `--latest` and `--backup-id` with selection resolution logic; update `backup` README and add `docs/backups-registry-plan.md` describing design and migration. 

### Testing

- Added unit tests for the registry model (`internal/registry/registry_test.go`), backup upload registry integration (`internal/backup/operation_registry_test.go`), and retention behavior including rebuild/failure cases (`internal/backup/retention_registry_test.go`). 
- Ran `go test ./...` locally against the modified packages, and all new and existing unit tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abd5052270832c890a6d845525e9b8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backup Registry to track backups (id, filename, created_at, size, sha256, status, encryption, tool) with listing and rebuild support; auto-updates on backup operations.
  * Retention engine and command with policies (retention-count, max-age, keep-daily/weekly/monthly), plus --dry-run and --force.

* **CLI**
  * Restore: add --latest and --backup-id, enforce exactly one selector.
  * Backup: add skip-retention and retention flags; new registry list (ls) command.

* **Storage**
  * Storage backends expose List, Delete, UploadBytes/DownloadBytes and Close.

* **Documentation**
  * README updated with registry, retention, examples and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->