### PR TITLE
[pipeline] collect errors from all stages

### DIFF
--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -68,9 +69,12 @@ func Run(ctx context.Context, src io.Reader, dst io.Writer, stages ...StageFunc)
 	wg.Wait()
 	close(errCh)
 
-	// Return first error encountered
+	// Collect errors from all stages for richer diagnostics
+	var errs []error
 	for err := range errCh {
-		return err
+		if err != nil {
+			errs = append(errs, err)
+		}
 	}
-	return nil
+	return errors.Join(errs...)
 }

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -372,6 +372,65 @@ func TestRun_EmptyInput(t *testing.T) {
 	}
 }
 
+// Test that errors from multiple failed stages are all collected.
+func TestRun_MultipleErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		stages     []pipeline.StageFunc
+		wantErrors []string
+	}{
+		{
+			name: "two stages fail independently",
+			stages: []pipeline.StageFunc{
+				errorStage(0, "first failure"),
+			},
+			wantErrors: []string{"stage 0 error: first failure"},
+		},
+		{
+			name: "two stages fail (cascade)",
+			stages: []pipeline.StageFunc{
+				failingStage,
+				identity,
+			},
+			wantErrors: []string{
+				"stage 0 failed",
+				"stage 1 failed",
+			},
+		},
+		{
+			name: "all stages fail",
+			stages: []pipeline.StageFunc{
+				failingStage,
+				failingStage,
+				failingStage,
+			},
+			wantErrors: []string{
+				"stage 0 failed",
+				"stage 1 failed",
+				"stage 2 failed",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var dst bytes.Buffer
+			src := strings.NewReader("test")
+
+			err := pipeline.Run(context.TODO(), src, &dst, tt.stages...)
+			if err == nil {
+				t.Fatal("Expected error, got nil")
+			}
+
+			for _, want := range tt.wantErrors {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("Expected error to contain %q, got: %v", want, err)
+				}
+			}
+		})
+	}
+}
+
 // errorReader is a reader that always returns an error.
 type errorReader struct {
 	err error


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pipeline error handling to collect and report all stage and copy failures together, rather than stopping at the first error.
  * When no failures occur, the pipeline now finishes cleanly without returning an error.
* **Tests**
  * Added a new test covering multiple simultaneous failure scenarios (including mixed and cascading failures) to ensure all expected error details are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->