### PR TITLE
[backup] add `mariadb-dump` support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,37 @@ MARIADB__PASSWORD=secure_password
 #   --slave-info (for replication setups)
 MARIADB__BACKUP_OPTIONS=
 
+# Backup Method
+# Purpose: Select backup method - physical (mariadb-backup) or logical (mariadb-dump)
+# Format: string ("mariadb-backup" or "mariadb-dump")
+# Default: mariadb-backup
+# Required: No
+# Notes:
+#   - mariadb-backup: Hot physical backup (requires mariadb-backup binary)
+#   - mariadb-dump: Logical SQL dump (requires mariadb-dump binary)
+#     Produces per-database .sql files. Restore via: mysql < file.sql
+MARIADB__BACKUP_METHOD=mariadb-backup
+
+# MariaDB Backup Binary
+# Purpose: Path to the backup binary
+# Format: string (binary name or full path)
+# Default: auto-derived from MARIADB__BACKUP_METHOD
+# Required: No
+# Notes:
+#   - Auto-derived: mariadb-backup for physical, mariadb-dump for logical
+#   - Override only if binary is in a non-standard location
+MARIADB__BACKUP_BINARY=
+
+# MariaDB Client Binary
+# Purpose: Path to the mariadb client binary (used to list databases for logical backup)
+# Format: string (binary name or full path)
+# Default: mariadb
+# Required: No
+# Notes:
+#   - Only used when MARIADB__BACKUP_METHOD=mariadb-dump
+#   - Override only if mariadb client is in a non-standard location
+MARIADB__CLIENT_BINARY=mariadb
+
 # =============================================================================
 # 📦 STORAGE CONFIGURATION
 # =============================================================================

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,14 @@
 # This file is licensed under the terms of the MIT license https://opensource.org/license/mit
-# Copyright (c) 2021-2025 Marat Reymers
+# Copyright (c) 2021-2025 Marat Reimers
 
-## Golden config for golangci-lint v2.5.0
+## Golden config for golangci-lint v2.9.0
 #
 # This is the best config for golangci-lint based on my experience and opinion.
 # It is very strict, but not extremely strict.
 # Feel free to adapt it to suit your needs.
-# If this config helps you, please consider keeping a link to this file (see the next comment).
+# If this config helps you, please consider keeping a link to this repo (see the next comment).
 
-# Based on https://gist.github.com/maratori/47a4d00457a92aa426dbd48a18776322
+# Based on https://github.com/maratori/golangci-lint-config
 
 version: "2"
 
@@ -82,6 +82,7 @@ linters:
     - makezero # finds slice declarations with non-zero initial length
     - mirror # reports wrong mirror patterns of bytes/strings usage
     - mnd # detects magic numbers
+    - modernize # suggests simplifications to Go code, using modern language and library features
     - musttag # enforces field tags in (un)marshaled structs
     - nakedret # finds naked returns in functions greater than a specified function length
     - nestif # reports deeply nested if statements
@@ -241,6 +242,7 @@ linters:
       # Default: []
       exclude:
         # std libs
+        - ^net.ListenConfig$
         - ^net/http.Client$
         - ^net/http.Cookie$
         - ^net/http.Request$
@@ -251,11 +253,25 @@ linters:
         - ^os/exec.Cmd$
         - ^reflect.StructField$
         # public libs
+        - ^firebase.google.com/go/v4/messaging.AndroidConfig$
+        - ^firebase.google.com/go/v4/messaging.Message$
         - ^github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager.+Input$
         - ^github.com/aws/aws-sdk-go-v2/service/s3.+Input$
         - ^github.com/aws/aws-sdk-go-v2/service/s3/types.ObjectIdentifier$
+        - ^github.com/go-telegram-bot-api/telegram-bot-api/.+Config$
+        - ^github.com/go-telegram/bot.+Params$
+        - ^github.com/go-telegram/bot/models.+$
+        - ^github.com/gofiber/.+Config$
+        - ^github.com/golang-jwt/jwt/v5.+Claims$
+        - ^github.com/invopop/jsonschema.Reflector$
         - ^github.com/mitchellh/mapstructure.DecoderConfig$
+        - ^github.com/mymmrac/telego.+Params$
+        - ^github.com/openai/openai-go/v3/shared\.ResponseFormatJSONSchemaJSONSchemaParam$
+        - ^github.com/openai/openai-go/v3/shared\.ResponseFormatJSONSchemaParam$
+        - ^github.com/openai/openai-go/v3\.ChatCompletionNewParams$
+        - ^github.com/openai/openai-go/v3\.ChatCompletionNewParamsResponseFormatUnion$
         - ^github.com/prometheus/client_golang/.+Opts$
+        - ^github.com/revrost/go-openrouter.+$
         - ^github.com/secsy/goftp.Config$
         - ^github.com/Shopify/sarama.Config$
         - ^github.com/Shopify/sarama.ProducerMessage$
@@ -264,12 +280,18 @@ linters:
         - ^github.com/stretchr/testify/mock.Mock$
         - ^github.com/testcontainers/testcontainers-go.+Request$
         - ^github.com/testcontainers/testcontainers-go.FromDockerfile$
+        - ^github.com/ThreeDotsLabs/watermill.+(Config|Schema|Adapter)$
         - ^github.com/urfave/cli.v3.ArgumentBase$
         - ^github.com/urfave/cli.v3.Command$
         - ^github.com/urfave/cli.v3.FlagBase$
+        - ^github.com/valyala/fasthttp.Client$
         - ^golang.org/x/tools/go/analysis.Analyzer$
         - ^google.golang.org/protobuf/.+Options$
+        - ^gopkg.in/telebot.v4.LongPoller$
+        - ^gopkg.in/telebot.v4.ReplyMarkup$
+        - ^gopkg.in/telebot.v4.Settings$
         - ^gopkg.in/yaml.v3.Node$
+        - ^gorm.io/gorm/clause.+$
       # Allows empty structures in return statements.
       # Default: false
       allow-empty-returns: true
@@ -320,6 +342,15 @@ linters:
         # Assert no unused link in godocs.
         # https://github.com/godoc-lint/godoc-lint?tab=readme-ov-file#no-unused-link
         - no-unused-link
+        # Require proper doc links to standard library declarations where applicable.
+        # https://github.com/godoc-lint/godoc-lint?tab=readme-ov-file#require-stdlib-doclink
+        - require-stdlib-doclink
+
+    gosec:
+      # To specify a set of rules to explicitly exclude.
+      # Available rules: https://github.com/securego/gosec#available-rules
+      excludes:
+        - G704 # SSRF via taint analysis
 
     govet:
       # Enable all analyzers.
@@ -435,10 +466,13 @@ linters:
       # Default: false
       os-temp-dir: true
 
+    wrapcheck:
+      extra-ignore-sigs:
+        - .JSON(
+        - .SendStatus(
+
   exclusions:
-    # Log a warning if an exclusion rule is unused.
-    # Default: false
-    warn-unused: true
+    generated: lax
     # Predefined exclusion rules.
     # Default: []
     presets:
@@ -450,6 +484,8 @@ linters:
         linters: [godot]
       - text: "should have a package comment"
         linters: [revive]
+      - text: "avoid package names that conflict with Go standard library package names"
+        linters: [revive]
       - text: 'exported \S+ \S+ should have comment( \(or a comment on this block\))? or be unexported'
         linters: [revive]
       - text: 'package comment should be of the form ".+"'
@@ -458,18 +494,15 @@ linters:
       - text: 'comment on exported \S+ \S+ should be of the form ".+"'
         source: "// ?(nolint|TODO)"
         linters: [revive, staticcheck]
-      - path: 'internal/storage/mock\.go'
-        linters:
-          - errcheck
-          - wrapcheck
       - path: '_test\.go'
         linters:
-          - err113
           - bodyclose
           - dupl
+          - err113
           - errcheck
           - exhaustruct
           - funlen
+          - gocognit
           - goconst
           - gosec
           - noctx

--- a/README.md
+++ b/README.md
@@ -1,325 +1,309 @@
-# 🗄️ MariaDB Backup to S3
+<a id="readme-top"></a>
 
-![Go Version](https://img.shields.io/github/go-mod/go-version/capcom6/mariadb-backup-s3)
-![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)
+<!-- PROJECT SHIELDS -->
+[![Contributors][contributors-shield]][contributors-url]
+[![Forks][forks-shield]][forks-url]
+[![Stargazers][stars-shield]][stars-url]
+[![Issues][issues-shield]][issues-url]
+[![License][license-shield]][license-url]
+![Go Version][go-version-shield]
 
-🔁 Automated MariaDB database backups with S3-compatible storage integration
+<!-- PROJECT HEADER -->
+<br />
+<div align="center">
+  <h1>MariaDB Backup to S3</h1>
+  <p>
+    Automated MariaDB backups with S3-compatible storage support.<br />
+    Physical (<code>mariadb-backup</code>) or logical (<code>mariadb-dump</code>) backups, compressed, optionally encrypted, stored locally or in S3/FTP.
+  </p>
 
-## Table of Contents
-- [🗄️ MariaDB Backup to S3](#️-mariadb-backup-to-s3)
-  - [Table of Contents](#table-of-contents)
-  - [🚀 Quick Start](#-quick-start)
-  - [✨ Features](#-features)
-  - [🛠️ How It Works](#️-how-it-works)
-    - [Temporary Working Directory](#temporary-working-directory)
-    - [Backup Registry](#backup-registry)
-  - [📋 Prerequisites](#-prerequisites)
-  - [📦 Installation](#-installation)
-    - [Binary Installation (Recommended)](#binary-installation-recommended)
-    - [Using Go Install](#using-go-install)
-    - [Docker](#docker)
-    - [From Source (Advanced)](#from-source-advanced)
-  - [⚙️ Configuration](#️-configuration)
-    - [Logging Configuration](#logging-configuration)
-  - [🚀 Usage](#-usage)
-    - [Backup](#backup)
-    - [Restore](#restore)
-    - [Retention](#retention)
-    - [Registry](#registry)
-    - [Scheduler](#scheduler)
-  - [📂 Storage Types](#-storage-types)
-    - [S3 Storage](#s3-storage)
-    - [FTP Storage](#ftp-storage)
-    - [Filesystem Storage](#filesystem-storage)
-  - [🔐 Encryption](#-encryption)
-    - [Security Considerations](#security-considerations)
-      - [Key Management](#key-management)
-      - [Key Generation](#key-generation)
-  - [📝 Examples](#-examples)
-  - [🤝 Contributing](#-contributing)
-  - [👥 Contributors](#-contributors)
-  - [📄 License](#-license)
+  <a href="https://github.com/capcom6/mariadb-backup-s3/releases/latest">Download</a>
+  &middot;
+  <a href="https://github.com/capcom6/mariadb-backup-s3/issues/new?labels=bug&template=bug-report---.md">Report Bug</a>
+  &middot;
+  <a href="https://github.com/capcom6/mariadb-backup-s3/issues/new?labels=enhancement&template=feature-request---.md">Request Feature</a>
+</div>
+
+<!-- TABLE OF CONTENTS -->
+- [About The Project](#about-the-project)
+  - [Built With](#built-with)
+- [Getting Started](#getting-started)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+- [Usage](#usage)
+  - [Backup](#backup)
+  - [Restore](#restore)
+  - [Retention](#retention)
+  - [Registry](#registry)
+  - [Scheduler](#scheduler)
+- [Storage Types](#storage-types)
+  - [S3 Storage](#s3-storage)
+  - [FTP Storage](#ftp-storage)
+  - [Filesystem Storage](#filesystem-storage)
+- [Encryption](#encryption)
+- [Examples](#examples)
+- [Contributing](#contributing)
+- [License](#license)
+- [Contact](#contact)
+- [Acknowledgments](#acknowledgments)
 
 
-## 🚀 Quick Start
+<!-- ABOUT THE PROJECT -->
+## About The Project
 
-```shell
-# Using pre-built binary (check Releases page for latest version)
-curl -LO https://github.com/capcom6/mariadb-backup-s3/releases/latest/download/mariadb-backup-s3_Linux_x86_64.tar.gz
-tar -xzf mariadb-backup-s3_Linux_x86_64.tar.gz
-chmod +x mariadb-backup-s3
-./mariadb-backup-s3 --help
+MariaDB Backup to S3 is a CLI tool that backs up MariaDB databases, compresses them, optionally encrypts them with AES-256-GCM, and uploads to S3-compatible, FTP, or local filesystem storage.
 
-# Or via go install
-go install github.com/capcom6/mariadb-backup-s3@latest
+**Two backup methods are supported:**
 
-# Configure & run
-cp .env.example .env
-nano .env  # Edit with your credentials
-./mariadb-backup-s3
-```
+| Method                 | Binary           | Description                                                                                                             |
+| ---------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| **Physical** (default) | `mariadb-backup` | Hot backup at the storage engine level. Produces a tar.gz archive. Restore by copying files back to the data directory. |
+| **Logical**            | `mariadb-dump`   | SQL dump of each database as a separate `.sql` file, tarred together. Restore by importing the `.sql` files you need.   |
 
-## ✨ Features
+**Key features:**
 
-- 🛡️ Full database backups using `mariabackup`
-- 🗜️ Compression to `.tar.gz` format
-- 🔑 Optional encryption using AES-256-GCM
-- ☁️ Multiple storage backends (S3-compatible, FTP, filesystem)
-- 🔌 Pluggable storage interface for extensibility
-- 🔄 Automatic backup rotation with configurable retention policies
-- 📋 Backup registry for tracking and managing backups
-- 🐳 Docker container support
-- ⏰ Built-in scheduler — run scheduled backups as a long-running daemon, no external cron needed
+- Compress backups with pigz (parallel gzip)
+- Optional AES-256-GCM client-side encryption
+- Multiple storage backends: S3-compatible, FTP, filesystem
+- Automatic backup rotation with configurable retention policies
+- Backup registry for tracking and managing backups
+- Built-in scheduler daemon for automated scheduled backups without external cron
+- Docker container support
 
-## 🛠️ How It Works
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
-The backup process follows these steps:
+### Built With
 
-1. 📂 Create temporary working directory
-2. 💾 Perform MariaDB backup using `mariabackup --backup`
-3. 🔧 Prepare backup for consistency using `mariabackup --prepare`
-4. 🗜️ Compress backup to `.tar.gz` archive
-5. 🔑 Encrypt archive using AES-256-GCM
-6. 🚀 Upload archive to configured storage backend
-7. 📋 Update backup registry with new backup metadata
-8. 🧹 Clean up old backups based on retention policy (unless `--skip-retention` is set)
+- [Go](https://go.dev/)
+- [mariadb-backup](https://mariadb.com/docs/server/server-usage/backup-and-restore/backup-and-restore-overview#mariadb-backup) / [mariadb-dump](https://mariadb.com/docs/server/server-usage/backup-and-restore/backup-and-restore-overview#mariadb-dump)
+- [AWS SDK for Go v2](https://aws.github.io/aws-sdk-go-v2/)
+- [pigz](https://zlib.net/pigz/) (parallel gzip)
 
-The restore process follows these steps:
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
-1. 📥 Download the backup file from the specified storage backend
-2. 🔑 Decrypt the backup using AES-256-GCM
-3. 🗜️ Decompress the `.tar.gz` archive
-4. 🔄 Restore the database files to specified directory
+<!-- GETTING STARTED -->
+## Getting Started
 
-### Temporary Working Directory
+### Prerequisites
 
-The tool uses a temporary working directory to store intermediate files. By default, it uses the system's default temporary directory (e.g., `/tmp`). If for some reason you need to use a different directory, you can specify it via the `TMPDIR` environment variable.
-
-```bash
-export TMPDIR=/mnt/data/backup
-./mariadb-backup-s3 backup
-```
-
-### Backup Registry
-
-The tool maintains a backup registry (`.backup-registry.json`) in the storage backend to track all backups. This registry enables:
-
-- **Backup tracking**: Each backup is recorded with metadata including ID, filename, creation time, size, SHA256 hash, encryption status, and tool version
-- **Retention management**: The registry is used to apply retention policies and clean up old backups
-- **Backup listing**: View all available backups with their status and metadata
-
-The registry is automatically updated when backups are created or deleted. Each backup entry includes:
-
-| Field        | Description                                   |
-| ------------ | --------------------------------------------- |
-| `id`         | Unique identifier (timestamp + SHA256 prefix) |
-| `filename`   | Backup filename                               |
-| `created_at` | Creation timestamp                            |
-| `size_bytes` | File size in bytes                            |
-| `sha256`     | SHA256 hash of the backup file                |
-| `status`     | Status: `ready`, `failed`, or `deleted`       |
-| `encrypted`  | Whether the backup is encrypted               |
-| `encryption` | Encryption metadata (algorithm)               |
-| `tool`       | Tool name and version                         |
-
-## 📋 Prerequisites
-
-- Go 1.23+ (for building from source)
-- MariaDB server
-- At least 2x the actual database size in free space (for successful backup)
+- Go 1.25+ (for building from source)
+- MariaDB server with `mariadb-backup` (for physical) or `mariadb-dump` (for logical) available in PATH, and `mariadb` client binary for listing databases (logical backup only)
+- `pigz` in PATH
+- `tar` in PATH
+- At least 2x the database size in free temp space
 - Storage backend credentials (depending on chosen storage type)
 
-## 📦 Installation
+### Installation
 
-### Binary Installation (Recommended)
+**Binary (recommended):**
+
 1. Visit the [Releases page](https://github.com/capcom6/mariadb-backup-s3/releases/latest)
 2. Download the appropriate binary for your OS
-3. Make executable: `chmod +x mariadb-backup-s3`
-4. Move to PATH: `sudo mv mariadb-backup-s3 /usr/local/bin/`
+3. Make executable and move to PATH:
+   ```sh
+   chmod +x mariadb-backup-s3
+   sudo mv mariadb-backup-s3 /usr/local/bin/
+   ```
 
-### Using Go Install
-```shell
+**Go install:**
+
+```sh
 go install github.com/capcom6/mariadb-backup-s3@latest
 ```
 
-### Docker
-```shell
+**Docker:**
+
+```sh
 docker pull ghcr.io/capcom6/mariadb-backup-s3:latest
 ```
 
 > **Note**
-> The Docker image uses MariaDB's `lts` version. For specific versions:
-> 1. Clone the repository
-> 2. Modify `Dockerfile` base image
-> 3. Build custom image: `docker build -t custom-backup-image .`
+> The Docker image uses MariaDB's `lts` version. For specific versions, clone the repo, modify `Dockerfile.goreleaser` base image, and build a custom image.
 
-### From Source (Advanced)
-```shell
+**From source:**
+
+```sh
 git clone https://github.com/capcom6/mariadb-backup-s3.git
 cd mariadb-backup-s3
 go build -o mariadb-backup-s3
 ```
 
-## ⚙️ Configuration
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
-The tool supports loading configuration from multiple sources:
+<!-- USAGE -->
+## Usage
 
-1. `.env` file in the current directory
-2. Environment variables
-3. Command-line flags
-
-The priority order is: `.env` > Environment variables > Command-line flags
-
-### Logging Configuration
-
-The logging system can be configured via environment variables:
-
-- `LOG_LEVEL`: Set log level (debug, info, warn, error, fatal). Default: info
-- `LOG_FORMAT`: Set format (human, json). Default: human
-- `LOG_OUTPUT`: Set output destination:
-  - `stdout` (default): Standard output
-  - `stderr`: Standard error
-  - Any file path: Write logs to the specified file
-- `NO_COLOR`: When set (any non-empty value), disables colored output for human format
-
-## 🚀 Usage
-
-```bash
+```sh
 mariadb-backup-s3 [global options] command [command options] [arguments...]
 ```
 
-The tool offers the following commands:
-
-| Command              | Description                                       |
-| -------------------- | ------------------------------------------------- |
-| `backup`             | Perform a backup of the MariaDB database          |
-| `restore`            | Restore the database files to specified directory |
-| `retention`          | Apply retention policies to backups               |
-| `registry`           | Manage backup registry                            |
-| `scheduler`, `sched` | Run the backup scheduler daemon                   |
+Configuration is loaded from (highest priority first): CLI flags > environment variables > `.env` file in the current directory.
 
 ### Backup
 
-```bash
+```sh
 mariadb-backup-s3 backup [options]
 ```
 
 **Options:**
 
-| Option                        | Env Var                   | Description                                       | Default value    |
-| ----------------------------- | ------------------------- | ------------------------------------------------- | ---------------- |
-| **Database**                  |                           |                                                   |                  |
-| `--db-host`, `--host`         | `MARIADB__HOST`           | MariaDB hostname                                  | `localhost`      |
-| `--db-port`, `--port`         | `MARIADB__PORT`           | MariaDB port                                      | `3306`           |
-| `--db-user`, `--user`         | `MARIADB__USER`           | MariaDB username                                  | `root`           |
-| `--db-password`, `--password` | `MARIADB__PASSWORD`       | MariaDB password                                  | `""`             |
-| **Storage**                   |                           |                                                   |                  |
-| `--storage`, `--storage-url`  | `STORAGE__URL`            | Storage URL, see [Storage Types](#-storage-types) | **required**     |
-| **Encryption**                |                           |                                                   |                  |
-| `--encryption-key`            | `ENCRYPTION__KEY`         | Encryption key                                    | `""`             |
-| **mariadb-backup**            |                           |                                                   |                  |
-| `--db-backup-binary`          | `MARIADB__BACKUP_BINARY`  | MariaDB backup binary path                        | `mariadb-backup` |
-| `--db-backup-options`         | `MARIADB__BACKUP_OPTIONS` | MariaDB backup options                            | `""`             |
-| **Retention**                 |                           |                                                   |                  |
-| `--retention-count`           | `RETENTION__COUNT`        | Number of backups to retain, 0 = unlimited        | `0`              |
-| `--max-age`                   | `RETENTION__MAX_AGE`      | Maximum age of backups to keep (e.g. 24h, 168h)   | unlimited        |
-| `--keep-daily`                | `RETENTION__KEEP_DAILY`   | Number of daily backups to keep                   | unlimited        |
-| `--keep-weekly`               | `RETENTION__KEEP_WEEKLY`  | Number of weekly backups to keep                  | unlimited        |
-| `--keep-monthly`              | `RETENTION__KEEP_MONTHLY` | Number of monthly backups to keep                 | unlimited        |
-| `--skip-retention`            | `BACKUP__SKIP_RETENTION`  | Skip retention policy after backup                | `false`          |
+| Option                        | Env Var                   | Description                                                | Default                             |
+| ----------------------------- | ------------------------- | ---------------------------------------------------------- | ----------------------------------- |
+| **Database**                  |                           |                                                            |                                     |
+| `--db-host`, `--host`         | `MARIADB__HOST`           | MariaDB hostname                                           | `localhost`                         |
+| `--db-port`, `--port`         | `MARIADB__PORT`           | MariaDB port                                               | `3306`                              |
+| `--db-user`, `--user`         | `MARIADB__USER`           | MariaDB username                                           | `root`                              |
+| `--db-password`, `--password` | `MARIADB__PASSWORD`       | MariaDB password                                           | `""`                                |
+| `--backup-method`             | `MARIADB__BACKUP_METHOD`  | `mariadb-backup` (physical) or `mariadb-dump` (logical)    | `mariadb-backup`                    |
+| `--db-backup-binary`          | `MARIADB__BACKUP_BINARY`  | Backup binary path                                         | auto-derived from `--backup-method` |
+| `--db-client-binary`          | `MARIADB__CLIENT_BINARY`  | mariadb client binary (lists databases for logical backup) | `mariadb`                           |
+| `--db-backup-options`         | `MARIADB__BACKUP_OPTIONS` | Extra backup options                                       | `""`                                |
+| **Storage**                   |                           |                                                            |                                     |
+| `--storage-url`, `--storage`  | `STORAGE__URL`            | Storage URL (see [Storage Types](#storage-types))          | **required**                        |
+| **Encryption**                |                           |                                                            |                                     |
+| `--encryption-key`            | `ENCRYPTION__KEY`         | Base64-encoded AES-256 key                                 | `""`                                |
+| **Retention**                 |                           |                                                            |                                     |
+| `--retention-count`           | `RETENTION__COUNT`        | Number of backups to retain (0 = unlimited)                | `0`                                 |
+| `--max-age`                   | `RETENTION__MAX_AGE`      | Maximum age of backups (e.g. `24h`, `168h`)                | unlimited                           |
+| `--keep-daily`                | `RETENTION__KEEP_DAILY`   | Number of daily backups to keep                            | `0` (disabled)                      |
+| `--keep-weekly`               | `RETENTION__KEEP_WEEKLY`  | Number of weekly backups to keep                           | `0` (disabled)                      |
+| `--keep-monthly`              | `RETENTION__KEEP_MONTHLY` | Number of monthly backups to keep                          | `0` (disabled)                      |
+| `--skip-retention`            | `BACKUP__SKIP_RETENTION`  | Skip retention policy after backup                         | `false`                             |
 
-**Example:**
+**Physical backup example:**
 
-```shell
-./mariadb-backup-s3 backup \
+```sh
+mariadb-backup-s3 backup \
   --db-host=mariadb.example.com \
   --db-user=backup \
-  --storage-url="file:///var/backups/mariadb"
+  --storage-url="s3://my-bucket/backups?endpoint=https://s3.eu-west-1.amazonaws.com" \
+  --retention-count=14 \
+  --keep-daily=7
 ```
+
+**Logical backup example:**
+
+```sh
+mariadb-backup-s3 backup \
+  --backup-method=mariadb-dump \
+  --db-host=mariadb.example.com \
+  --db-user=backup \
+  --storage-url="s3://my-bucket/backups"
+```
+
+By default `mariadb-dump` locks tables per database using `READ LOCAL` locks, so concurrent inserts into non-transactional tables (e.g. MyISAM/Aria) may still occur while a table is dumped, and cross-database consistency is not guaranteed. Each database is dumped in a separate invocation, so the generated `.sql` files are not point-in-time consistent with each other; as a result, logical (`mariadb-dump`) backups do not provide a global snapshot of all databases. The virtual schemas `information_schema` and `performance_schema` are skipped. For non-blocking dumps (InnoDB only), use `--db-backup-options="--single-transaction"`, accepting that non-transactional tables are then not guaranteed consistent.
+
+**Environment-only (minimal):**
+
+```sh
+export MARIADB__HOST=localhost
+export MARIADB__USER=root
+export MARIADB__PASSWORD=secret
+export MARIADB__BACKUP_METHOD=mariadb-backup
+export STORAGE__URL=s3://my-bucket/backups
+export AWS_REGION=eu-west-1
+export AWS_ACCESS_KEY_ID=xxx
+export AWS_SECRET_ACCESS_KEY=yyy
+mariadb-backup-s3
+```
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ### Restore
 
-```bash
+```sh
 mariadb-backup-s3 restore [options] [backup_name.tar.gz | --latest | --backup-id=<id>]
 ```
 
+Exactly one backup selector must be specified: a filename argument, `--latest`, or `--backup-id`.
+
 **Options:**
 
-| Option                       | Env Var               | Description                                       | Default value |
-| ---------------------------- | --------------------- | ------------------------------------------------- | ------------- |
-| **Storage**                  |                       |                                                   |               |
-| `--storage`, `--storage-url` | `STORAGE__URL`        | Storage URL, see [Storage Types](#-storage-types) | **required**  |
-| **Encryption**               |                       |                                                   |               |
-| `--encryption-key`           | `ENCRYPTION__KEY`     | Encryption key                                    | `""`          |
-| **Restore**                  |                       |                                                   |               |
-| `--target-dir`               | `RESTORE__TARGET_DIR` | Target directory to restore files to              | **required**  |
-| `--latest`                   |                       | Restore latest ready backup from registry         | `false`       |
-| `--backup-id`                |                       | Restore backup by registry backup ID              | `""`          |
+| Option                       | Env Var               | Description                               | Default      |
+| ---------------------------- | --------------------- | ----------------------------------------- | ------------ |
+| `--storage-url`, `--storage` | `STORAGE__URL`        | Storage URL                               | **required** |
+| `--encryption-key`           | `ENCRYPTION__KEY`     | Encryption key                            | `""`         |
+| `--target-dir`               | `RESTORE__TARGET_DIR` | Target directory to restore to            | **required** |
+| `--latest`                   |                       | Restore latest ready backup from registry | `false`      |
+| `--backup-id`                |                       | Restore backup by registry ID             | `""`         |
+
+**Restore latest backup:**
+
+```sh
+mariadb-backup-s3 restore \
+  --storage-url="s3://bucket/path" \
+  --target-dir=/var/lib/mysql \
+  --latest
+```
+
+**Restore by filename or ID:**
+
+```sh
+mariadb-backup-s3 restore --storage-url="s3://bucket/path" \
+  --target-dir=/tmp/restore \
+  2026-07-03-12-00-00.tar.gz
+
+mariadb-backup-s3 restore --storage-url="s3://bucket/path" \
+  --target-dir=/tmp/restore \
+  2026-07-03-12-00-00.tar.gz.enc  # .enc suffix for encrypted backups
+
+mariadb-backup-s3 restore --storage-url="s3://bucket/path" \
+  --target-dir=/tmp/restore \
+  --backup-id="2026-07-03-12-00-00-a1b2c3d4"
+```
 
 > **Note**
-> Exactly one backup selector must be specified: either a filename argument, `--latest`, or `--backup-id`.
+> Logical backups (`mariadb-dump`) restore by extracting `.sql` files from the archive. Import them manually:
+> ```sh
+> mariadb-backup-s3 restore --storage-url="s3://bucket/path" --target-dir=/tmp/restore --latest
+> mariadb -u root -p < /tmp/restore/mydb.sql
+> ```
 
-**Arguments:**
-
-| Argument   | Description      |
-| ---------- | ---------------- |
-| `filename` | Backup file name |
-
-**Example:**
-
-```shell
-./mariadb-backup-s3 restore \
-  --storage-url="file:///var/backups/mariadb" \
-  --target-dir=/var/lib/mariadb \
-  backup_name.tar.gz
-```
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ### Retention
 
-The `retention` command applies retention policies to backups stored in the configured storage backend. This allows you to clean up old backups based on various criteria.
+Apply retention policies to prune old backups.
 
-```bash
+```sh
 mariadb-backup-s3 retention [options]
 ```
 
 **Options:**
 
-| Option              | Env Var                   | Description                                          | Default value |
-| ------------------- | ------------------------- | ---------------------------------------------------- | ------------- |
-| **Storage**         |                           |                                                      |               |
-| `--storage-url`     | `STORAGE__URL`            | Storage URL, see [Storage Types](#-storage-types)    | **required**  |
-| **Retention**       |                           |                                                      |               |
-| `--retention-count` | `RETENTION__COUNT`        | Number of backups to retain, 0 = unlimited           | `0`           |
-| `--max-age`         | `RETENTION__MAX_AGE`      | Maximum age of backups to keep (e.g. 24h, 168h)      | unlimited     |
-| `--keep-daily`      | `RETENTION__KEEP_DAILY`   | Number of daily backups to keep                      | unlimited     |
-| `--keep-weekly`     | `RETENTION__KEEP_WEEKLY`  | Number of weekly backups to keep                     | unlimited     |
-| `--keep-monthly`    | `RETENTION__KEEP_MONTHLY` | Number of monthly backups to keep                    | unlimited     |
-| **Options**         |                           |                                                      |               |
-| `--dry-run`         | `RETENTION__DRY_RUN`      | Show what would be deleted without actually deleting | `false`       |
-| `--force`           | `RETENTION__FORCE`        | Continue even if errors occur                        | `false`       |
+| Option              | Env Var                   | Description                      | Default        |
+| ------------------- | ------------------------- | -------------------------------- | -------------- |
+| `--storage-url`     | `STORAGE__URL`            | Storage URL                      | **required**   |
+| `--retention-count` | `RETENTION__COUNT`        | Number of backups to retain      | `0`            |
+| `--max-age`         | `RETENTION__MAX_AGE`      | Maximum age (e.g. `24h`, `168h`) | unlimited      |
+| `--keep-daily`      | `RETENTION__KEEP_DAILY`   | Keep N per day                   | `0` (disabled) |
+| `--keep-weekly`     | `RETENTION__KEEP_WEEKLY`  | Keep N per week                  | `0` (disabled) |
+| `--keep-monthly`    | `RETENTION__KEEP_MONTHLY` | Keep N per month                 | `0` (disabled) |
+| `--dry-run`         | `RETENTION__DRY_RUN`      | Preview without deleting         | `false`        |
+| `--force`           | `RETENTION__FORCE`        | Continue despite errors          | `false`        |
 
-**Retention Policy Examples:**
+**Examples:**
 
-```shell
+```sh
 # Keep only the 7 most recent backups
-./mariadb-backup-s3 retention \
+mariadb-backup-s3 retention \
   --storage-url="s3://my-bucket/backups" \
   --retention-count=7
 
 # Keep backups from the last 7 days
-./mariadb-backup-s3 retention \
+mariadb-backup-s3 retention \
   --storage-url="s3://my-bucket/backups" \
   --max-age=168h
 
-# Keep 1 daily backup for 7 days, 1 weekly for 4 weeks, 1 monthly for 12 months
-./mariadb-backup-s3 retention \
+# Keep 1 daily for 7 days, 1 weekly for 4 weeks, 1 monthly for 12 months
+mariadb-backup-s3 retention \
   --storage-url="s3://my-bucket/backups" \
   --keep-daily=7 \
   --keep-weekly=4 \
   --keep-monthly=12
 
-# Preview what would be deleted without actually deleting
-./mariadb-backup-s3 retention \
+# Preview what would be deleted
+mariadb-backup-s3 retention \
   --storage-url="s3://my-bucket/backups" \
   --retention-count=3 \
   --dry-run
@@ -328,49 +312,52 @@ mariadb-backup-s3 retention [options]
 > **Note**
 > At least one retention policy must be enabled. The retention command will fail if no policies are specified.
 
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
 ### Registry
 
-The `registry` command allows you to manage and view the backup registry.
+View and manage the backup registry.
 
-```bash
-mariadb-backup-s3 registry [command] [options]
+```sh
+mariadb-backup-s3 registry list [options]
 ```
 
-**Subcommands:**
+| Option          | Env Var        | Description                                               | Default      |
+| --------------- | -------------- | --------------------------------------------------------- | ------------ |
+| `--storage-url` | `STORAGE__URL` | Storage URL                                               | **required** |
+| `--rebuild`     |                | Rebuild the registry from stored backups if it is missing | `false`      |
 
-| Command | Alias | Description                |
-| ------- | ----- | -------------------------- |
-| `list`  | `ls`  | List backups from registry |
-
-**List Command Options:**
-
-| Option          | Env Var        | Description                                       | Default value |
-| --------------- | -------------- | ------------------------------------------------- | ------------- |
-| `--storage-url` | `STORAGE__URL` | Storage URL, see [Storage Types](#-storage-types) | **required**  |
-
-**Example:**
-
-```shell
-./mariadb-backup-s3 registry list \
+```sh
+mariadb-backup-s3 registry list \
   --storage-url="s3://my-bucket/backups"
 ```
 
-**Output:**
+**Registry entry fields:**
 
-The list command displays all backups in the registry with the following information:
-- **ID**: Unique backup identifier
-- **Created At**: Backup creation timestamp
-- **Status**: Backup status (`ready`, `failed`, or `deleted`)
-- **Encrypted**: Whether the backup is encrypted
-- **Size**: Backup file size in bytes
-- **Filename**: Backup filename
+| Field                       | Description                                       |
+| --------------------------- | ------------------------------------------------- |
+| `id`                        | Unique identifier (timestamp + SHA256 prefix)     |
+| `filename`                  | Backup filename                                   |
+| `created_at`                | Creation timestamp                                |
+| `size_bytes`                | File size in bytes                                |
+| `sha256`                    | SHA256 hash of the backup file                    |
+| `status`                    | `ready`, `failed`, or `deleted`                   |
+| `encrypted`                 | Whether the backup is encrypted                   |
+| `encryption`                | Encryption metadata (algorithm)                   |
+| `tool.name`, `tool.version` | Tool name and version                             |
+| `tool.method`               | Backup method: `mariadb-backup` or `mariadb-dump` |
+
+> **Note**
+> Entries rebuilt with `--rebuild` use timestamp-only IDs, set `sha256` to `"unknown"`, and have an empty `tool.method`.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ### Scheduler
 
-The `scheduler` command runs a built-in cron daemon that executes backup and retention jobs on a schedule without relying on external cron or systemd timers.
+Built-in cron daemon that executes backup and retention jobs on a schedule without external cron or systemd timers.
 
-```bash
-mariadb-backup-s3 scheduler [command] [options]
+```sh
+mariadb-backup-s3 scheduler <command> [options]
 ```
 
 **Subcommands:**
@@ -381,26 +368,15 @@ mariadb-backup-s3 scheduler [command] [options]
 | `status` | Show the status of scheduled jobs     |
 | `check`  | Validate a scheduler YAML config file |
 
-**Common Options:**
+**Options:**
 
-| Option     | Env Var             | Description                        | Default value |
-| ---------- | ------------------- | ---------------------------------- | ------------- |
-| `--config` | `SCHEDULER__CONFIG` | Path to scheduler YAML config file | **required**  |
+| Option         | Env Var                 | Description                         | Default      |
+| -------------- | ----------------------- | ----------------------------------- | ------------ |
+| `--config`     | `SCHEDULER__CONFIG`     | Path to scheduler YAML config       | **required** |
+| `--state-file` | `SCHEDULER__STATE_FILE` | Path to persistent state file       | from config  |
+| `--once`       |                         | Run all enabled jobs once then exit | `false`      |
 
-**Scheduler Run Options:**
-
-| Option         | Env Var                 | Description                     | Default value |
-| -------------- | ----------------------- | ------------------------------- | ------------- |
-| `--state-file` | `SCHEDULER__STATE_FILE` | Path to persistent state file   | from config   |
-| `--once`       |                         | Run all due jobs once then exit | `false`       |
-
-**Scheduler Status Options:**
-
-| Option         | Env Var                 | Description                   | Default value            |
-| -------------- | ----------------------- | ----------------------------- | ------------------------ |
-| `--state-file` | `SCHEDULER__STATE_FILE` | Path to persistent state file | `/tmp/mariadb-scheduler-state.json` |
-
-**Example:**
+**Example scheduler config:**
 
 ```yaml
 # scheduler.yaml
@@ -417,136 +393,178 @@ jobs:
       port: 3306
       user: root
       password: ${MARIADB__PASSWORD}
+      backup_method: mariadb-backup
     retention:
       max_count: 7
 ```
 
-```bash
+```sh
 # Validate the config
 mariadb-backup-s3 scheduler check --config scheduler.yaml
 
 # Run the scheduler daemon
 mariadb-backup-s3 scheduler run --config scheduler.yaml
 
-# Run all due jobs once and exit
+# Run all enabled jobs once and exit
 mariadb-backup-s3 scheduler run --config scheduler.yaml --once
 
 # Check job status
-mariadb-backup-s3 scheduler status --state-file /var/lib/mariadb-backup-s3/state.json
+mariadb-backup-s3 scheduler status --config scheduler.yaml --state-file /var/lib/mariadb-backup-s3/state.json
 ```
 
 > **Note**
-> The scheduler replaces the need for external cron, systemd timers, or shell scripts. See [examples/scheduler](./examples/scheduler/) for a complete setup guide.
+> See [examples/scheduler](./examples/scheduler/) for a complete setup guide.
 
-## 📂 Storage Types
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- STORAGE TYPES -->
+## Storage Types
 
 ### S3 Storage
-For S3-compatible storage (including AWS S3, MinIO, DigitalOcean Spaces, etc.):
+
+For S3-compatible storage (AWS S3, MinIO, DigitalOcean Spaces, etc.):
 
 ```dotenv
 STORAGE__URL=s3://bucket-name/path?endpoint=https://s3.example.com
 ```
 
-**Required for S3:**
-- `AWS_ACCESS_KEY`: Your access key
-- `AWS_SECRET_KEY`: Your secret key
-- `AWS_REGION`: AWS region (or any region for non-AWS S3)
+**Required environment variables:**
 
-**Query Parameters:**
-- `endpoint`: S3 endpoint URL
-- `s3-force-path-style`: Set to "true" to use path-style URLs
-- `part-size`: Multipart upload part size in bytes (default: 10485760 = 10 MB, minimum: 5242880 = 5 MB)
+| Env Var                 | Description |
+| ----------------------- | ----------- |
+| `AWS_REGION`            | AWS region  |
+| `AWS_ACCESS_KEY_ID`     | Access key  |
+| `AWS_SECRET_ACCESS_KEY` | Secret key  |
+
+**Query parameters:**
+
+| Parameter             | Description                                                                          |
+| --------------------- | ------------------------------------------------------------------------------------ |
+| `endpoint`            | S3 endpoint URL                                                                      |
+| `s3-force-path-style` | Set to `true` to use path-style URLs                                                 |
+| `part-size`           | Multipart upload part size in bytes (default: 10485760 = 10 MB, min: 5242880 = 5 MB) |
 
 ### FTP Storage
-For FTP servers:
 
 ```dotenv
 STORAGE__URL=ftp://username:password@host:port/path
 ```
 
-**Required for FTP:**
-- `username`: FTP username (defaults to "anonymous" if not provided)
-- `password`: FTP password (optional for anonymous)
-- `host`: FTP server hostname
-- `port`: FTP port (defaults to 21)
+Username defaults to `anonymous`.
 
 ### Filesystem Storage
-For local or mounted filesystem storage:
 
 ```dotenv
 STORAGE__URL=file:///absolute/path/to/backup/directory
 ```
 
-**Examples:**
+Examples:
 - Linux/macOS: `file:///var/backups/mariadb`
-- Windows: `file://C:/backups/mariadb`
+- Windows: `file:///C:/backups/mariadb`
 - Docker volume: `file:///data/backups`
 
-## 🔐 Encryption
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
-The backup system supports client-side encryption using AES-256 in Galois/Counter Mode (GCM) to ensure your database backups remain confidential and secure. This method provides both confidentiality and integrity verification.
+<!-- ENCRYPTION -->
+## Encryption
+
+Client-side encryption using AES-256-GCM for confidentiality and integrity verification.
 
 **Features:**
 - 256-bit key strength
-- Authenticated encryption with additional data (AEAD)
-- Automatic nonce generation for each backup
+- Authenticated encryption with associated data (AEAD)
+- Automatic nonce generation per backup
+- HKDF-SHA256 key derivation
 
 **Configuration:**
+
 ```dotenv
 # base64-encoded encryption key
-ENCRYPTION__KEY=Av2cfWJ3enCHTyzPdzowfAXshvJtbEsvwgPjV46wnjc=
+# Replace with a unique value generated by: openssl rand -base64 32
+ENCRYPTION__KEY=REPLACE_WITH_A_UNIQUE_BASE64_KEY
 ```
 
-### Security Considerations
+**Key generation:**
 
-#### Key Management
-- **Never commit encryption keys to version control**
-- Store keys in secure environment variables or dedicated secret management systems
-- Implement proper access controls for key storage
-
-#### Key Generation
-Generate secure encryption keys using cryptographically secure methods:
-
-```bash
-# Generate a 32-byte (256-bit) key for AES256-GCM
+```sh
+# Generate a 32-byte (256-bit) key
 openssl rand -base64 32
 
-# Alternative method using /dev/urandom
+# Alternative
 head -c 32 /dev/urandom | base64
 ```
 
-## 📝 Examples
+**Security considerations:**
 
-- **systemd Service Example**: [examples/systemd-service](./examples/systemd-service/)
-- **Docker Swarm CRON Example**: [examples/docker-cron-backup](./examples/docker-cron-backup/)
-- **Simple CRON Example**: [examples/simple-cron-backup](./examples/simple-cron-backup/)
-- **Advanced CRON Example**: [examples/advanced-cron-backup](./examples/advanced-cron-backup/)
-- **Encryption Example**: [examples/encryption-example](./examples/encryption-example/)
-- **Scheduler Example**: [examples/scheduler](./examples/scheduler/)
+- Never commit encryption keys to version control
+- Store keys in secure environment variables or dedicated secret management systems
+- Implement proper access controls for key storage
 
-## 🤝 Contributing
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
-We welcome contributions! Please follow these steps:
+<!-- EXAMPLES -->
+## Examples
 
-1. 🍴 Fork the repository
-2. 🌿 Create a feature branch: `git checkout -b feat/amazing-feature`
-3. 💾 Commit changes: `git commit -m 'Add amazing feature'`
-4. 🚀 Push to branch: `git push origin feat/amazing-feature`
-5. 🔀 Create a Pull Request
+- [systemd Service](./examples/systemd-service/) -- Run as a systemd service
+- [Docker Swarm CRON](./examples/docker-cron-backup/) -- Scheduled backups in Docker Swarm
+- [Simple CRON](./examples/simple-cron-backup/) -- Basic cron-based scheduling
+- [Advanced CRON](./examples/advanced-cron-backup/) -- Advanced cron with logging and notifications
+- [Encryption](./examples/encryption-example/) -- Encrypted backup setup
+- [Scheduler](./examples/scheduler/) -- Built-in scheduler daemon
 
-## 👥 Contributors
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
-A big thank you to everyone who has contributed to this project!
+<!-- CONTRIBUTING -->
+## Contributing
 
-- [gslongo](https://github.com/gslongo)
+Contributions are what make the open source community such an amazing place to learn, inspire, and create. Any contributions you make are **greatly appreciated**.
 
-See the full [CONTRIBUTORS.md](CONTRIBUTORS.md) file for more information.
+1. Fork the Project
+2. Create your Feature Branch (`git checkout -b feature/amazing-feature`)
+3. Commit your Changes (`git commit -m 'Add amazing feature'`)
+4. Push to the Branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
 
-## 📄 License
+See [CONTRIBUTORS.md](CONTRIBUTORS.md) for a list of contributors.
 
-Apache 2.0 - See [LICENSE](LICENSE) for details.
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
----
+<!-- LICENSE -->
+## License
 
-💡 **Need Help?** Open an [issue](https://github.com/capcom6/mariadb-backup-s3/issues) for support.
+Distributed under the Apache 2.0 License. See [LICENSE](LICENSE) for details.
 
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- CONTACT -->
+## Contact
+
+- [Report a bug](https://github.com/capcom6/mariadb-backup-s3/issues/new?labels=bug&template=bug-report---.md)
+- [Request a feature](https://github.com/capcom6/mariadb-backup-s3/issues/new?labels=enhancement&template=feature-request---.md)
+- [View all issues](https://github.com/capcom6/mariadb-backup-s3/issues)
+
+Project Link: [https://github.com/capcom6/mariadb-backup-s3](https://github.com/capcom6/mariadb-backup-s3)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- ACKNOWLEDGMENTS -->
+## Acknowledgments
+
+- [Choose an Open Source License](https://choosealicense.com)
+- [Img Shields](https://shields.io)
+- [Best-README-Template](https://github.com/othneildrew/Best-README-Template)
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- MARKDOWN LINKS & IMAGES -->
+[contributors-shield]: https://img.shields.io/github/contributors/capcom6/mariadb-backup-s3.svg?style=for-the-badge
+[contributors-url]: https://github.com/capcom6/mariadb-backup-s3/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/capcom6/mariadb-backup-s3.svg?style=for-the-badge
+[forks-url]: https://github.com/capcom6/mariadb-backup-s3/network/members
+[stars-shield]: https://img.shields.io/github/stars/capcom6/mariadb-backup-s3.svg?style=for-the-badge
+[stars-url]: https://github.com/capcom6/mariadb-backup-s3/stargazers
+[issues-shield]: https://img.shields.io/github/issues/capcom6/mariadb-backup-s3.svg?style=for-the-badge
+[issues-url]: https://github.com/capcom6/mariadb-backup-s3/issues
+[license-shield]: https://img.shields.io/github/license/capcom6/mariadb-backup-s3.svg?style=for-the-badge
+[license-url]: https://github.com/capcom6/mariadb-backup-s3/blob/master/LICENSE
+[go-version-shield]: https://img.shields.io/github/go-mod/go-version/capcom6/mariadb-backup-s3?style=for-the-badge

--- a/examples/scheduler/config.yaml
+++ b/examples/scheduler/config.yaml
@@ -73,3 +73,23 @@ jobs:
       password: ${MARIADB__PASSWORD}
     retention:
       keep_daily: 3
+
+  # ---------------------------------------------------------------------------
+  # Daily logical backup (mariadb-dump)
+  # Runs every day at 4:00 AM UTC, produces per-database .sql files
+  # Restore by importing: mysql < file.sql
+  # ---------------------------------------------------------------------------
+  - name: daily-logical-backup
+    schedule: "0 4 * * *"
+    command: backup
+    timeout: 4h
+    storage:
+      url: s3://my-bucket/backups?endpoint=https://s3.custom.com
+    mariadb:
+      host: localhost
+      port: 3306
+      user: root
+      password: ${MARIADB__PASSWORD}
+      backup_method: mariadb-dump
+    retention:
+      max_count: 7

--- a/internal/backup/method/config.go
+++ b/internal/backup/method/config.go
@@ -1,0 +1,11 @@
+package method
+
+type Config struct {
+	Host          string
+	Port          int
+	User          string
+	Password      string
+	BackupOptions string
+	BackupBinary  string
+	ClientBinary  string
+}

--- a/internal/backup/method/logical/logical.go
+++ b/internal/backup/method/logical/logical.go
@@ -161,7 +161,7 @@ func (m *Method) listDatabases(ctx context.Context) ([]string, error) {
 	databases := make([]string, 0)
 	for db := range strings.SplitSeq(raw, "\n") {
 		switch db {
-		case "information_schema", "performance_schema":
+		case "information_schema", "performance_schema", "sys":
 			continue
 		default:
 			databases = append(databases, db)

--- a/internal/backup/method/logical/logical.go
+++ b/internal/backup/method/logical/logical.go
@@ -1,0 +1,213 @@
+package logical
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/capcom6/mariadb-backup-s3/internal/backup/method"
+	"github.com/capcom6/mariadb-backup-s3/internal/exec"
+	"github.com/capcom6/mariadb-backup-s3/internal/logging"
+	"github.com/capcom6/mariadb-backup-s3/internal/sanitizer"
+)
+
+const MethodName = "mariadb-dump"
+
+// Method implements method.Method for mariadb-dump (logical/SQL backup).
+type Method struct {
+	config method.Config
+}
+
+// New creates a Method with the given MariaDB config.
+func New(cfg method.Config) *Method {
+	return &Method{config: cfg}
+}
+
+// MethodName returns the registry identifier for logical backups.
+func (m *Method) MethodName() string {
+	return MethodName
+}
+
+// Backup dumps each database as a separate .sql file into tempdir.
+// Note: each database is dumped in its own mariadb-dump invocation, so the
+// resulting .sql files are not point-in-time consistent across databases.
+func (m *Method) Backup(ctx context.Context, tempdir string, logger logging.Logger) error {
+	logger.Info(ctx, "Stage 1: Dump")
+	start := time.Now()
+	defer func() {
+		duration := time.Since(start)
+		logger.Info(ctx, "Stage 1 completed", logging.Fields{
+			"duration": duration.String(),
+		})
+	}()
+
+	databases, err := m.listDatabases(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list databases: %w", err)
+	}
+
+	logger.Info(ctx, "Databases found", logging.Fields{
+		"count": strconv.Itoa(len(databases)),
+	})
+
+	for _, db := range databases {
+		if dumpErr := m.dumpDatabase(ctx, tempdir, db, logger); dumpErr != nil {
+			return fmt.Errorf("failed to dump database %q: %w", db, dumpErr)
+		}
+	}
+
+	return nil
+}
+
+// Prepare is a no-op for logical backups.
+func (m *Method) Prepare(_ context.Context, _ string, _ logging.Logger) error {
+	return nil
+}
+
+// sharedOptionPrefixes lists BackupOptions flags that control the client
+// connection and must be applied to both database discovery and dumps.
+func isSharedConnectionOption(opt string) bool {
+	for _, prefix := range []string{"--socket", "--ssl", "--tls-", "--default-auth"} {
+		if strings.HasPrefix(opt, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Method) sanitizedOptions() ([]string, error) {
+	if m.config.BackupOptions == "" {
+		return nil, nil
+	}
+
+	opts, err := sanitizer.SanitizeOptions(m.config.BackupOptions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sanitize options: %w", err)
+	}
+
+	return opts, nil
+}
+
+func (m *Method) connectionArgs() ([]string, error) {
+	args := []string{}
+
+	if m.config.Host != "" {
+		args = append(args, "--host="+m.config.Host)
+	}
+
+	if m.config.Port != 0 {
+		args = append(args, "--port="+strconv.Itoa(m.config.Port))
+	}
+
+	args = append(args, "--user="+m.config.User)
+
+	opts, err := m.sanitizedOptions()
+	if err != nil {
+		return nil, err
+	}
+	for _, opt := range opts {
+		if isSharedConnectionOption(opt) {
+			args = append(args, opt)
+		}
+	}
+
+	return args, nil
+}
+
+func (m *Method) dumpOnlyArgs() ([]string, error) {
+	opts, err := m.sanitizedOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	args := make([]string, 0, len(opts))
+	for _, opt := range opts {
+		if !isSharedConnectionOption(opt) {
+			args = append(args, opt)
+		}
+	}
+
+	return args, nil
+}
+
+func (m *Method) listDatabases(ctx context.Context) ([]string, error) {
+	connArgs, err := m.connectionArgs()
+	if err != nil {
+		return nil, err
+	}
+
+	args := []string{
+		m.config.ClientBinary,
+		"-N",
+		"-e", "SHOW DATABASES",
+	}
+	args = append(args, connArgs...)
+
+	var stdout bytes.Buffer
+	if runErr := exec.Run(ctx, args, map[string]string{"MYSQL_PWD": m.config.Password}, &stdout); runErr != nil {
+		return nil, fmt.Errorf("failed to list databases: %w", runErr)
+	}
+
+	raw := strings.TrimSpace(stdout.String())
+	if raw == "" {
+		return nil, nil
+	}
+
+	databases := make([]string, 0)
+	for db := range strings.SplitSeq(raw, "\n") {
+		switch db {
+		case "information_schema", "performance_schema":
+			continue
+		default:
+			databases = append(databases, db)
+		}
+	}
+
+	return databases, nil
+}
+
+func (m *Method) dumpDatabase(ctx context.Context, tempdir string, db string, logger logging.Logger) error {
+	logger.Info(ctx, "Dumping database", logging.Fields{"database": db})
+
+	connArgs, err := m.connectionArgs()
+	if err != nil {
+		return err
+	}
+	dumpArgs, err := m.dumpOnlyArgs()
+	if err != nil {
+		return err
+	}
+
+	args := []string{
+		m.config.BackupBinary,
+		"--databases", db,
+		"--routines",
+		"--triggers",
+		"--events",
+	}
+	args = append(args, connArgs...)
+	args = append(args, dumpArgs...)
+
+	outFile, err := os.Create(filepath.Join(tempdir, db+".sql"))
+	if err != nil {
+		return fmt.Errorf("failed to create output file: %w", err)
+	}
+	defer func() {
+		if closeErr := outFile.Close(); closeErr != nil {
+			logger.Error(ctx, "Failed to close output file", closeErr, logging.Fields{
+				"database": db,
+			})
+		}
+	}()
+
+	if execErr := exec.Run(ctx, args, map[string]string{"MYSQL_PWD": m.config.Password}, outFile); execErr != nil {
+		return fmt.Errorf("mariadb-dump failed: %w", execErr)
+	}
+
+	return nil
+}

--- a/internal/backup/method/logical/logical_internal_test.go
+++ b/internal/backup/method/logical/logical_internal_test.go
@@ -1,0 +1,48 @@
+package logical
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/capcom6/mariadb-backup-s3/internal/backup/method"
+)
+
+func TestConnectionArgs_AppliesSharedOptionsToDiscovery(t *testing.T) {
+	m := New(method.Config{
+		Host:          "db.example.com",
+		Port:          3307,
+		User:          "backup",
+		BackupOptions: "--single-transaction --socket=/var/run/mysqld/mysqld.sock --ssl",
+	})
+
+	connArgs, err := m.connectionArgs()
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"--host=db.example.com",
+		"--port=3307",
+		"--user=backup",
+		"--socket=/var/run/mysqld/mysqld.sock",
+		"--ssl",
+	}, connArgs)
+
+	dumpArgs, err := m.dumpOnlyArgs()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"--single-transaction"}, dumpArgs)
+}
+
+func TestConnectionArgs_EmptyOptions(t *testing.T) {
+	m := New(method.Config{
+		Host: "localhost",
+		User: "root",
+	})
+
+	connArgs, err := m.connectionArgs()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"--host=localhost", "--user=root"}, connArgs)
+
+	dumpArgs, err := m.dumpOnlyArgs()
+	require.NoError(t, err)
+	assert.Empty(t, dumpArgs)
+}

--- a/internal/backup/method/logical/logical_test.go
+++ b/internal/backup/method/logical/logical_test.go
@@ -1,0 +1,46 @@
+package logical_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/capcom6/mariadb-backup-s3/internal/backup/method"
+	"github.com/capcom6/mariadb-backup-s3/internal/backup/method/logical"
+	"github.com/capcom6/mariadb-backup-s3/internal/logging"
+)
+
+func TestNew(t *testing.T) {
+	cfg := method.Config{
+		Host:         "localhost",
+		Port:         3306,
+		User:         "root",
+		Password:     "secret",
+		BackupBinary: "mariadb-dump",
+	}
+
+	m := logical.New(cfg)
+	assert.NotNil(t, m)
+}
+
+func TestMethod_MethodName(t *testing.T) {
+	cfg := method.Config{
+		BackupBinary: "mariadb-dump",
+	}
+
+	m := logical.New(cfg)
+	assert.Equal(t, logical.MethodName, m.MethodName())
+}
+
+func TestMethod_Prepare_NoOp(t *testing.T) {
+	cfg := method.Config{
+		BackupBinary: "mariadb-dump",
+	}
+
+	m := logical.New(cfg)
+	logger := logging.NewTestLogger()
+	err := m.Prepare(context.Background(), "/tmp/nonexistent", logger)
+	require.NoError(t, err)
+}

--- a/internal/backup/method/method.go
+++ b/internal/backup/method/method.go
@@ -1,0 +1,24 @@
+package method
+
+import (
+	"context"
+
+	"github.com/capcom6/mariadb-backup-s3/internal/logging"
+)
+
+// Method defines the interface for backup tool implementations.
+// Physical (mariadb-backup) and logical (mariadb-dump) methods both
+// produce files in a temp directory that the caller compresses, encrypts,
+// and uploads through a shared pipeline.
+type Method interface {
+	// Backup executes the backup tool, writing output files into tempdir.
+	Backup(ctx context.Context, tempdir string, logger logging.Logger) error
+
+	// Prepare runs any post-backup preparation step.
+	// Physical backups require mariadb-backup --prepare; logical backups return nil.
+	Prepare(ctx context.Context, tempdir string, logger logging.Logger) error
+
+	// MethodName returns the identifier stored in registry metadata
+	// (e.g. "mariadb-backup" or "mariadb-dump").
+	MethodName() string
+}

--- a/internal/backup/method/physical/physical.go
+++ b/internal/backup/method/physical/physical.go
@@ -1,0 +1,99 @@
+package physical
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"time"
+
+	"github.com/capcom6/mariadb-backup-s3/internal/backup/method"
+	"github.com/capcom6/mariadb-backup-s3/internal/exec"
+	"github.com/capcom6/mariadb-backup-s3/internal/logging"
+	"github.com/capcom6/mariadb-backup-s3/internal/sanitizer"
+)
+
+const MethodName = "mariadb-backup"
+
+// Method implements method.Method for mariadb-backup (physical/hot backup).
+type Method struct {
+	config method.Config
+}
+
+// New creates a Method with the given MariaDB config.
+func New(cfg method.Config) *Method {
+	return &Method{config: cfg}
+}
+
+// MethodName returns the registry identifier for physical backups.
+func (m *Method) MethodName() string {
+	return MethodName
+}
+
+// Backup executes mariadb-backup --backup, writing data files into tempdir.
+func (m *Method) Backup(ctx context.Context, tempdir string, logger logging.Logger) error {
+	logger.Info(ctx, "Stage 1: Backup")
+	start := time.Now()
+	defer func() {
+		duration := time.Since(start)
+		logger.Info(ctx, "Stage 1 completed", logging.Fields{
+			"duration": duration.String(),
+		})
+	}()
+
+	args := []string{
+		m.config.BackupBinary,
+		"--backup",
+		"--parallel=" + strconv.Itoa(runtime.NumCPU()),
+		"--target-dir=" + tempdir,
+		"--user=" + m.config.User,
+	}
+
+	if m.config.Host != "" {
+		args = append(args, "--host="+m.config.Host)
+	}
+
+	if m.config.Port != 0 {
+		args = append(args, "--port="+strconv.Itoa(m.config.Port))
+	}
+
+	if m.config.BackupOptions != "" {
+		opts, err := sanitizer.SanitizeOptions(m.config.BackupOptions)
+		if err != nil {
+			return fmt.Errorf("failed to sanitize options: %w", err)
+		}
+
+		args = append(args, opts...)
+	}
+
+	if err := exec.Run(ctx, args, map[string]string{"MYSQL_PWD": m.config.Password}, os.Stdout); err != nil {
+		return fmt.Errorf("mariadb-backup --backup failed: %w", err)
+	}
+
+	return nil
+}
+
+// Prepare executes mariadb-backup --prepare on the backup data in tempdir.
+func (m *Method) Prepare(ctx context.Context, tempdir string, logger logging.Logger) error {
+	logger.Info(ctx, "Stage 2: Prepare")
+	start := time.Now()
+	defer func() {
+		duration := time.Since(start)
+		logger.Info(ctx, "Stage 2 completed", logging.Fields{
+			"duration": duration.String(),
+		})
+	}()
+
+	args := []string{
+		m.config.BackupBinary,
+		"--prepare",
+		"--target-dir=" + tempdir,
+	}
+
+	if err := exec.Run(ctx, args, nil, os.Stdout); err != nil {
+		return fmt.Errorf("mariadb-backup --prepare failed: %w", err)
+	}
+
+	return nil
+}

--- a/internal/backup/method/physical/physical_test.go
+++ b/internal/backup/method/physical/physical_test.go
@@ -1,0 +1,41 @@
+package physical_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/capcom6/mariadb-backup-s3/internal/backup/method"
+	"github.com/capcom6/mariadb-backup-s3/internal/backup/method/physical"
+)
+
+func TestNew(t *testing.T) {
+	cfg := method.Config{
+		Host:         "localhost",
+		Port:         3306,
+		User:         "root",
+		Password:     "secret",
+		BackupBinary: "mariadb-backup",
+	}
+
+	m := physical.New(cfg)
+	assert.NotNil(t, m)
+}
+
+func TestMethod_MethodName(t *testing.T) {
+	cfg := method.Config{
+		BackupBinary: "mariadb-backup",
+	}
+
+	m := physical.New(cfg)
+	assert.Equal(t, physical.MethodName, m.MethodName())
+}
+
+func TestMethod_ImplementsInterface(_ *testing.T) {
+	cfg := method.Config{
+		BackupBinary: "mariadb-backup",
+	}
+
+	m := physical.New(cfg)
+	var _ method.Method = m
+}

--- a/internal/backup/operation.go
+++ b/internal/backup/operation.go
@@ -9,15 +9,15 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
-	"runtime"
-	"strconv"
+	osexec "os/exec"
 	"time"
 
+	"github.com/capcom6/mariadb-backup-s3/internal/backup/method"
+	"github.com/capcom6/mariadb-backup-s3/internal/backup/method/logical"
+	"github.com/capcom6/mariadb-backup-s3/internal/backup/method/physical"
 	"github.com/capcom6/mariadb-backup-s3/internal/encryption"
 	"github.com/capcom6/mariadb-backup-s3/internal/logging"
 	"github.com/capcom6/mariadb-backup-s3/internal/registry"
-	"github.com/capcom6/mariadb-backup-s3/internal/sanitizer"
 	"github.com/capcom6/mariadb-backup-s3/internal/storage"
 	"github.com/capcom6/mariadb-backup-s3/pkg/counting"
 	"github.com/capcom6/mariadb-backup-s3/pkg/pipeline"
@@ -33,6 +33,8 @@ const (
 type Operation struct {
 	config Config
 
+	method method.Method
+
 	registrySvc *registry.Service
 
 	storage storage.Backend
@@ -46,8 +48,26 @@ func NewOperation(
 	storage storage.Backend,
 	logger logging.Logger,
 ) *Operation {
+	var m method.Method
+	mConfig := method.Config{
+		Host:          config.MariaDB.Host,
+		Port:          config.MariaDB.Port,
+		User:          config.MariaDB.User,
+		Password:      config.MariaDB.Password,
+		BackupOptions: config.MariaDB.BackupOptions,
+		BackupBinary:  config.MariaDB.BackupBinary,
+		ClientBinary:  config.MariaDB.ClientBinary,
+	}
+	if config.MariaDB.IsLogical() {
+		m = logical.New(mConfig)
+	} else {
+		m = physical.New(mConfig)
+	}
+
 	return &Operation{
 		config: config,
+
+		method: m,
 
 		registrySvc: registrySvc,
 
@@ -87,14 +107,14 @@ func (o *Operation) Run(ctx context.Context) error {
 		}
 	}()
 
-	if bkpErr := o.backup(ctx, tempdir); bkpErr != nil {
+	if bkpErr := o.method.Backup(ctx, tempdir, o.logger); bkpErr != nil {
 		return fmt.Errorf("failed to backup: %w", bkpErr)
 	}
 	o.logger.Info(ctx, "backup done", logging.Fields{
 		logFieldTempdir: tempdir,
 	})
 
-	if prepErr := o.prepare(ctx, tempdir); prepErr != nil {
+	if prepErr := o.method.Prepare(ctx, tempdir, o.logger); prepErr != nil {
 		return fmt.Errorf("failed to prepare: %w", prepErr)
 	}
 	o.logger.Info(ctx, "prepare done", logging.Fields{
@@ -120,63 +140,6 @@ func (o *Operation) Run(ctx context.Context) error {
 	return nil
 }
 
-func (o *Operation) backup(ctx context.Context, tempdir string) error {
-	o.logger.Info(ctx, "Stage 1: Backup")
-	start := time.Now()
-	defer func() {
-		duration := time.Since(start)
-		o.logger.Info(ctx, "Stage 1 completed", logging.Fields{
-			logFieldDuration: duration.String(),
-		})
-	}()
-
-	args := []string{
-		o.config.MariaDB.BackupBinary,
-		"--backup",
-		"--parallel=" + strconv.Itoa(runtime.NumCPU()),
-		"--target-dir=" + tempdir,
-		"--user=" + o.config.MariaDB.User,
-	}
-
-	if o.config.MariaDB.Host != "" {
-		args = append(args, "--host="+o.config.MariaDB.Host)
-	}
-
-	if o.config.MariaDB.Port != 0 {
-		args = append(args, "--port="+strconv.Itoa(o.config.MariaDB.Port))
-	}
-
-	if o.config.MariaDB.BackupOptions != "" {
-		opts, err := sanitizer.SanitizeOptions(o.config.MariaDB.BackupOptions)
-		if err != nil {
-			return fmt.Errorf("failed to sanitize options: %w", err)
-		}
-
-		args = append(args, opts...)
-	}
-
-	return run(ctx, args, map[string]string{"MYSQL_PWD": o.config.MariaDB.Password})
-}
-
-func (o *Operation) prepare(ctx context.Context, tempdir string) error {
-	o.logger.Info(ctx, "Stage 2: Prepare")
-	start := time.Now()
-	defer func() {
-		duration := time.Since(start)
-		o.logger.Info(ctx, "Stage 2 completed", logging.Fields{
-			logFieldDuration: duration.String(),
-		})
-	}()
-
-	args := []string{
-		o.config.MariaDB.BackupBinary,
-		"--prepare",
-		"--target-dir=" + tempdir,
-	}
-
-	return run(ctx, args, nil)
-}
-
 func (o *Operation) compress(ctx context.Context, tempdir string, w io.Writer) error {
 	o.logger.Info(ctx, "Stage 3: Compress")
 	start := time.Now()
@@ -188,8 +151,8 @@ func (o *Operation) compress(ctx context.Context, tempdir string, w io.Writer) e
 	}()
 
 	// Create tar command
-	tarCmd := exec.CommandContext(ctx, "tar", "-C", tempdir, "-cf", "-", ".")
-	pigzCmd := exec.CommandContext(ctx, "pigz")
+	tarCmd := osexec.CommandContext(ctx, "tar", "-C", tempdir, "-cf", "-", ".")
+	pigzCmd := osexec.CommandContext(ctx, "pigz")
 
 	// Set up piping
 	var err error
@@ -289,6 +252,7 @@ func (o *Operation) upload(ctx context.Context, r io.Reader, targetName string, 
 		&registry.ToolMetadata{
 			Name:    "mariadb-backup-s3",
 			Version: o.config.Version,
+			Method:  o.method.MethodName(),
 		},
 	)
 

--- a/internal/backup/operation_internal_test.go
+++ b/internal/backup/operation_internal_test.go
@@ -1,0 +1,185 @@
+package backup
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/capcom6/mariadb-backup-s3/internal/config"
+	"github.com/capcom6/mariadb-backup-s3/internal/logging"
+	"github.com/capcom6/mariadb-backup-s3/internal/registry"
+	"github.com/capcom6/mariadb-backup-s3/internal/storage"
+)
+
+type mockMethod struct {
+	mock.Mock
+
+	callOrder []string
+	mu        sync.Mutex
+}
+
+func (m *mockMethod) Backup(_ context.Context, tempdir string, _ logging.Logger) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.callOrder = append(m.callOrder, "Backup")
+	args := m.Called(tempdir)
+	return args.Error(0)
+}
+
+func (m *mockMethod) Prepare(_ context.Context, tempdir string, _ logging.Logger) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.callOrder = append(m.callOrder, "Prepare")
+	args := m.Called(tempdir)
+	return args.Error(0)
+}
+
+func (m *mockMethod) MethodName() string {
+	return "test-method"
+}
+
+func (m *mockMethod) getCallOrder() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]string, len(m.callOrder))
+	copy(result, m.callOrder)
+	return result
+}
+
+func writeTestFile(t *testing.T, tempdir string) {
+	t.Helper()
+	err := os.WriteFile(filepath.Join(tempdir, "test.sql"), []byte("SELECT 1;"), 0o644)
+	require.NoError(t, err)
+}
+
+func newMockStorage(t *testing.T) (*storage.MockBackend, *registry.Service) {
+	t.Helper()
+	backend := &storage.MockBackend{}
+	backend.On("Upload", mock.Anything, mock.AnythingOfType("string"), mock.Anything).
+		Return(nil).Run(func(args mock.Arguments) {
+		r := args.Get(2).(io.Reader)
+		_, _ = io.Copy(io.Discard, r)
+	})
+	locker := &storage.MockLocker{}
+	locker.On("Unlock", mock.Anything).Return(nil)
+	backend.On("Lock", mock.Anything, ".backup-registry.json").Return(locker, nil)
+	backend.On("Download", mock.Anything, ".backup-registry.json", mock.Anything).
+		Return(nil).Run(func(args mock.Arguments) {
+		w := args.Get(2).(io.Writer)
+		reg := registry.New()
+		b, _ := json.Marshal(reg)
+		_, _ = w.Write(b)
+	})
+
+	regSvc := registry.NewService(backend)
+	return backend, regSvc
+}
+
+func TestOperation_Run_CallsBackupThenPrepare(t *testing.T) {
+	method := new(mockMethod)
+	method.On("Backup", mock.AnythingOfType("string")).Return(nil).Run(func(args mock.Arguments) {
+		writeTestFile(t, args.String(0))
+	})
+	method.On("Prepare", mock.AnythingOfType("string")).Return(nil)
+
+	backend, regSvc := newMockStorage(t)
+
+	logger := logging.NewTestLogger()
+	cfg := Config{
+		Version: "test",
+		MariaDB: config.MariaDB{
+			BackupBinary: "mariadb-backup",
+			BackupMethod: config.BackupMethodPhysical,
+			User:         "root",
+		},
+		Storage: config.Storage{URL: "file:///tmp/test"},
+	}
+
+	op := &Operation{
+		config:      cfg,
+		method:      method,
+		registrySvc: regSvc,
+		storage:     backend,
+		logger:      logger,
+	}
+
+	err := op.Run(context.Background())
+	require.NoError(t, err)
+
+	order := method.getCallOrder()
+	assert.Equal(t, []string{"Backup", "Prepare"}, order)
+	method.AssertExpectations(t)
+}
+
+func TestOperation_Run_BackupFails(t *testing.T) {
+	method := new(mockMethod)
+	method.On("Backup", mock.AnythingOfType("string")).Return(assert.AnError)
+
+	backend := &storage.MockBackend{}
+
+	logger := logging.NewTestLogger()
+	cfg := Config{
+		Version: "test",
+		MariaDB: config.MariaDB{
+			BackupBinary: "mariadb-backup",
+			BackupMethod: config.BackupMethodPhysical,
+			User:         "root",
+		},
+		Storage: config.Storage{URL: "file:///tmp/test"},
+	}
+
+	op := &Operation{
+		config:      cfg,
+		method:      method,
+		registrySvc: nil,
+		storage:     backend,
+		logger:      logger,
+	}
+
+	err := op.Run(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to backup")
+
+	method.AssertNotCalled(t, "Prepare", mock.Anything)
+}
+
+func TestOperation_Run_PrepareFails(t *testing.T) {
+	method := new(mockMethod)
+	method.On("Backup", mock.AnythingOfType("string")).Return(nil).Run(func(args mock.Arguments) {
+		writeTestFile(t, args.String(0))
+	})
+	method.On("Prepare", mock.AnythingOfType("string")).Return(assert.AnError)
+
+	backend := &storage.MockBackend{}
+
+	logger := logging.NewTestLogger()
+	cfg := Config{
+		Version: "test",
+		MariaDB: config.MariaDB{
+			BackupBinary: "mariadb-backup",
+			BackupMethod: config.BackupMethodPhysical,
+			User:         "root",
+		},
+		Storage: config.Storage{URL: "file:///tmp/test"},
+	}
+
+	op := &Operation{
+		config:      cfg,
+		method:      method,
+		registrySvc: nil,
+		storage:     backend,
+		logger:      logger,
+	}
+
+	err := op.Run(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to prepare")
+}

--- a/internal/cli/commands/backup/backup.go
+++ b/internal/cli/commands/backup/backup.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/capcom6/mariadb-backup-s3/internal/backup"
 	"github.com/capcom6/mariadb-backup-s3/internal/cli/flags"
+	"github.com/capcom6/mariadb-backup-s3/internal/config"
 	"github.com/capcom6/mariadb-backup-s3/internal/core/codes"
 	"github.com/capcom6/mariadb-backup-s3/internal/logging"
 	"github.com/capcom6/mariadb-backup-s3/internal/registry"
@@ -35,11 +36,23 @@ func Command() *cli.Command {
 		},
 		&cli.StringFlag{
 			Name:        "db-backup-binary",
-			Usage:       "mariadb-backup binary path",
-			DefaultText: "mariadb-backup",
+			Usage:       "backup binary path (auto-derived from --backup-method if not set)",
+			DefaultText: "auto-derived from --backup-method",
+			Sources:     cli.EnvVars("MARIADB__BACKUP_BINARY"),
+		},
+		&cli.StringFlag{
+			Name:        "db-client-binary",
+			Usage:       "mariadb client binary path for listing databases",
+			DefaultText: "mariadb",
+			Sources:     cli.EnvVars("MARIADB__CLIENT_BINARY"),
+		},
+		&cli.StringFlag{
+			Name:        "backup-method",
+			Usage:       "backup method: mariadb-backup (physical) or mariadb-dump (logical)",
+			DefaultText: config.BackupMethodPhysical,
 			Sources: cli.NewValueSourceChain(
-				cli.EnvVar("MARIADB__BACKUP_BINARY"),
-				cliutil.DefaultValue("mariadb-backup"),
+				cli.EnvVar("MARIADB__BACKUP_METHOD"),
+				cliutil.DefaultValue(config.BackupMethodPhysical),
 			),
 		},
 
@@ -78,6 +91,7 @@ func backupAction(ctx context.Context, cmd *cli.Command) error {
 		"db_password":       "***", // Don't log actual password
 		"db_backup_options": cmd.String("db-backup-options"),
 		"db_backup_binary":  cmd.String("db-backup-binary"),
+		"backup_method":     cmd.String("backup-method"),
 		logFieldStorageURL:  cmd.String("storage-url"),
 		"encryption_key":    "***", // Don't log actual key
 	})

--- a/internal/cli/commands/backup/config.go
+++ b/internal/cli/commands/backup/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/capcom6/mariadb-backup-s3/internal/backup"
+	"github.com/capcom6/mariadb-backup-s3/internal/config"
 	"github.com/urfave/cli/v3"
 )
 
@@ -18,7 +19,19 @@ func parseConfig(cmd *cli.Command) (backup.Config, error) {
 	cfg.MariaDB.User = cmd.String("db-user")
 	cfg.MariaDB.Password = cmd.String("db-password")
 	cfg.MariaDB.BackupOptions = cmd.String("db-backup-options")
+	cfg.MariaDB.BackupMethod = cmd.String("backup-method")
+
+	// Auto-derive binary from method if not explicitly set
 	cfg.MariaDB.BackupBinary = cmd.String("db-backup-binary")
+	if cfg.MariaDB.BackupBinary == "" {
+		cfg.MariaDB.BackupBinary = defaultBinaryForMethod(cfg.MariaDB.BackupMethod)
+	}
+
+	// Client binary defaults to mariadb
+	cfg.MariaDB.ClientBinary = cmd.String("db-client-binary")
+	if cfg.MariaDB.ClientBinary == "" {
+		cfg.MariaDB.ClientBinary = "mariadb"
+	}
 
 	// Configure storage
 	cfg.Storage.URL = cmd.String("storage-url")
@@ -32,4 +45,13 @@ func parseConfig(cmd *cli.Command) (backup.Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func defaultBinaryForMethod(method string) string {
+	switch method {
+	case config.BackupMethodLogical:
+		return "mariadb-dump"
+	default:
+		return "mariadb-backup"
+	}
 }

--- a/internal/cli/commands/registry/list.go
+++ b/internal/cli/commands/registry/list.go
@@ -85,6 +85,11 @@ func printRegistryTable(ctx context.Context, logger logging.Logger, reg *registr
 	})
 
 	for _, v := range reg.Backups {
+		method := ""
+		if v.Tool != nil {
+			method = v.Tool.Method
+		}
+
 		logger.Info(ctx, "Backup", logging.Fields{
 			"id":         v.ID,
 			"created_at": v.CreatedAt,
@@ -92,6 +97,7 @@ func printRegistryTable(ctx context.Context, logger logging.Logger, reg *registr
 			"encrypted":  v.Encrypted,
 			"size":       v.SizeBytes,
 			"filename":   v.Filename,
+			"method":     method,
 		})
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,9 +2,19 @@ package config
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/url"
 	"os/exec"
+)
+
+const (
+	BackupMethodPhysical = "mariadb-backup"
+	BackupMethodLogical  = "mariadb-dump"
+)
+
+var (
+	ErrInvalidBackupMethod = errors.New("invalid backup method")
 )
 
 type MariaDB struct {
@@ -14,11 +24,30 @@ type MariaDB struct {
 	Password      string
 	BackupOptions string
 	BackupBinary  string
+	ClientBinary  string
+	BackupMethod  string
+}
+
+func (m MariaDB) IsLogical() bool {
+	return m.BackupMethod == BackupMethodLogical
 }
 
 func (m MariaDB) Validate() error {
+	if m.BackupMethod != BackupMethodPhysical && m.BackupMethod != BackupMethodLogical {
+		return fmt.Errorf(
+			"%w: %q: must be %q or %q",
+			ErrInvalidBackupMethod, m.BackupMethod, BackupMethodPhysical, BackupMethodLogical,
+		)
+	}
+
 	if _, err := exec.LookPath(m.BackupBinary); err != nil {
-		return fmt.Errorf("mariabackup binary '%s' not found in PATH: %w", m.BackupBinary, err)
+		return fmt.Errorf("binary '%s' not found in PATH: %w", m.BackupBinary, err)
+	}
+
+	if m.IsLogical() {
+		if _, err := exec.LookPath(m.ClientBinary); err != nil {
+			return fmt.Errorf("client binary '%s' not found in PATH: %w", m.ClientBinary, err)
+		}
 	}
 
 	return nil
@@ -34,6 +63,8 @@ func DefaultMariaDB() MariaDB {
 		Password:      "",
 		BackupOptions: "",
 		BackupBinary:  "mariadb-backup",
+		ClientBinary:  "mariadb",
+		BackupMethod:  BackupMethodPhysical,
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,6 +16,9 @@ func TestDefaultMariaDB(t *testing.T) {
 	assert.Equal(t, 3306, cfg.Port)
 	assert.Equal(t, "root", cfg.User)
 	assert.Equal(t, "mariadb-backup", cfg.BackupBinary)
+	assert.Equal(t, "mariadb", cfg.ClientBinary)
+	assert.Equal(t, config.BackupMethodPhysical, cfg.BackupMethod)
+	assert.False(t, cfg.IsLogical())
 }
 
 func TestMariaDB_Validate_BinaryFound(t *testing.T) {
@@ -23,12 +26,8 @@ func TestMariaDB_Validate_BinaryFound(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := config.MariaDB{
-		Host:          "",
-		Port:          0,
-		User:          "",
-		Password:      "",
-		BackupOptions: "",
-		BackupBinary:  exe,
+		BackupBinary: exe,
+		BackupMethod: config.BackupMethodPhysical,
 	}
 	err = cfg.Validate()
 	assert.NoError(t, err)
@@ -36,15 +35,58 @@ func TestMariaDB_Validate_BinaryFound(t *testing.T) {
 
 func TestMariaDB_Validate_BinaryNotFound(t *testing.T) {
 	cfg := config.MariaDB{
-		Host:          "",
-		Port:          0,
-		User:          "",
-		Password:      "",
-		BackupOptions: "",
-		BackupBinary:  "nonexistent-binary-12345",
+		BackupBinary: "nonexistent-binary-12345",
+		BackupMethod: config.BackupMethodPhysical,
 	}
 	err := cfg.Validate()
 	assert.Error(t, err)
+}
+
+func TestMariaDB_Validate_InvalidMethod(t *testing.T) {
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	cfg := config.MariaDB{
+		BackupBinary: exe,
+		BackupMethod: "invalid-method",
+	}
+	err = cfg.Validate()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, config.ErrInvalidBackupMethod)
+}
+
+func TestMariaDB_Validate_LogicalMethod(t *testing.T) {
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	cfg := config.MariaDB{
+		BackupBinary: exe,
+		ClientBinary: exe,
+		BackupMethod: config.BackupMethodLogical,
+	}
+	err = cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestMariaDB_Validate_LogicalMethod_ClientBinaryNotFound(t *testing.T) {
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	cfg := config.MariaDB{
+		BackupBinary: exe,
+		ClientBinary: "nonexistent-client-binary-12345",
+		BackupMethod: config.BackupMethodLogical,
+	}
+	err = cfg.Validate()
+	assert.Error(t, err)
+}
+
+func TestMariaDB_IsLogical(t *testing.T) {
+	physical := config.MariaDB{BackupMethod: config.BackupMethodPhysical}
+	assert.False(t, physical.IsLogical())
+
+	logical := config.MariaDB{BackupMethod: config.BackupMethodLogical}
+	assert.True(t, logical.IsLogical())
 }
 
 func TestStorage_Validate_ValidURL(t *testing.T) {

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -1,10 +1,11 @@
-package backup
+package exec
 
 import (
 	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 )
@@ -13,7 +14,9 @@ var (
 	ErrNoArguments = errors.New("no arguments")
 )
 
-func run(ctx context.Context, args []string, extraEnv map[string]string) error {
+// Run executes an external command with optional extra environment variables.
+// stdout is forwarded to [os.Stdout]; stderr is captured and returned on failure.
+func Run(ctx context.Context, args []string, extraEnv map[string]string, stdout io.Writer) error {
 	if len(args) == 0 {
 		return ErrNoArguments
 	}
@@ -30,7 +33,7 @@ func run(ctx context.Context, args []string, extraEnv map[string]string) error {
 	for k, v := range extraEnv {
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}
-	cmd.Stdout = os.Stdout
+	cmd.Stdout = stdout
 	cmd.Stderr = &buf
 
 	if runErr := cmd.Run(); runErr != nil {

--- a/internal/registry/domain.go
+++ b/internal/registry/domain.go
@@ -64,6 +64,7 @@ type EncryptionMetadata struct {
 type ToolMetadata struct {
 	Name    string `json:"name,omitempty"`
 	Version string `json:"version,omitempty"`
+	Method  string `json:"method,omitempty"`
 }
 
 func New() *Registry {

--- a/internal/registry/service.go
+++ b/internal/registry/service.go
@@ -156,6 +156,7 @@ func (s *Service) rebuild(ctx context.Context) (*Registry, error) {
 			Tool: &ToolMetadata{
 				Name:    "mariadb-backup-s3",
 				Version: "unknown",
+				Method:  "",
 			},
 			Encryption: nil,
 		})

--- a/internal/registry/service_test.go
+++ b/internal/registry/service_test.go
@@ -639,6 +639,52 @@ func TestNewBackupEntry_WithEncryption(t *testing.T) {
 	assert.Equal(t, "test-tool", e.Tool.Name)
 }
 
+func TestNewBackupEntry_WithMethod(t *testing.T) {
+	now := fixedNow()
+	tool := &registry.ToolMetadata{
+		Name:    "mariadb-backup-s3",
+		Version: "1.0.0",
+		Method:  "mariadb-dump",
+	}
+	e := registry.NewBackupEntry(
+		"backup.tar.gz", now, 1024, "abcdef1234567890",
+		registry.StatusReady, false, nil, tool,
+	)
+	require.NotNil(t, e.Tool)
+	assert.Equal(t, "mariadb-dump", e.Tool.Method)
+}
+
+func TestToolMetadata_Method_SerializationRoundTrip(t *testing.T) {
+	now := fixedNow()
+	reg := registry.New()
+	reg.UpdatedAt = now
+	reg.Backups = []registry.BackupEntry{
+		{
+			ID:        "id1",
+			Filename:  "backup.tar.gz",
+			CreatedAt: now,
+			SizeBytes: 1024,
+			SHA256:    "abcdef1234567890",
+			Status:    registry.StatusReady,
+			Tool: &registry.ToolMetadata{
+				Name:    "mariadb-backup-s3",
+				Version: "1.0.0",
+				Method:  "mariadb-dump",
+			},
+		},
+	}
+
+	data, err := json.Marshal(reg)
+	require.NoError(t, err)
+
+	var decoded registry.Registry
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+	require.Len(t, decoded.Backups, 1)
+	require.NotNil(t, decoded.Backups[0].Tool)
+	assert.Equal(t, "mariadb-dump", decoded.Backups[0].Tool.Method)
+}
+
 func TestRegistryValidate_EmptyBackupsOK(t *testing.T) {
 	reg := registry.New()
 	reg.UpdatedAt = fixedNow()

--- a/internal/scheduler/export_test.go
+++ b/internal/scheduler/export_test.go
@@ -1,5 +1,14 @@
 package scheduler
 
+import (
+	"github.com/capcom6/mariadb-backup-s3/internal/config"
+	"github.com/capcom6/mariadb-backup-s3/internal/scheduler/repository"
+)
+
 func LoadState(filePath string) (*State, error) {
 	return loadState(filePath)
+}
+
+func BuildMariaDB(job repository.Job) config.MariaDB {
+	return (&Scheduler{}).buildMariaDB(job)
 }

--- a/internal/scheduler/repository/config.go
+++ b/internal/scheduler/repository/config.go
@@ -51,7 +51,9 @@ type MariaDB struct {
 	Port          int    `yaml:"port,omitempty"`
 	User          string `yaml:"user,omitempty"`
 	Password      string `yaml:"password,omitempty"`
+	BackupMethod  string `yaml:"backup_method,omitempty"`
 	BackupBinary  string `yaml:"backup_binary,omitempty"`
+	ClientBinary  string `yaml:"client_binary,omitempty"`
 	BackupOptions string `yaml:"backup_options,omitempty"`
 }
 
@@ -145,7 +147,7 @@ func (j Job) EncryptionKey() string {
 	return j.Encrypt.Key
 }
 
-func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (d *Duration) UnmarshalYAML(unmarshal func(any) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {
 		return fmt.Errorf("unmarshal duration: %w", err)

--- a/internal/scheduler/repository/config_test.go
+++ b/internal/scheduler/repository/config_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/capcom6/mariadb-backup-s3/internal/scheduler/repository"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestConfig_Validate(t *testing.T) {
@@ -231,4 +232,49 @@ func TestJob_GetTimeout(t *testing.T) {
 
 func boolPtr(b bool) *bool {
 	return &b
+}
+
+func TestConfig_YAML_BackupMethod(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `
+jobs:
+  - name: logical-backup
+    schedule: "0 2 * * *"
+    command: backup
+    storage:
+      url: "s3://bucket/path"
+    mariadb:
+      backup_method: mariadb-dump
+      host: localhost
+      user: root
+`
+	var cfg repository.Config
+	err := yaml.Unmarshal([]byte(yamlData), &cfg)
+	require.NoError(t, err)
+	require.Len(t, cfg.Jobs, 1)
+	require.NotNil(t, cfg.Jobs[0].MariaDB)
+	assert.Equal(t, "mariadb-dump", cfg.Jobs[0].MariaDB.BackupMethod)
+	assert.Equal(t, "localhost", cfg.Jobs[0].MariaDB.Host)
+}
+
+func TestConfig_YAML_BackupMethodOmitted(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `
+jobs:
+  - name: physical-backup
+    schedule: "0 2 * * *"
+    command: backup
+    storage:
+      url: "s3://bucket/path"
+    mariadb:
+      host: localhost
+`
+	var cfg repository.Config
+	err := yaml.Unmarshal([]byte(yamlData), &cfg)
+	require.NoError(t, err)
+	require.Len(t, cfg.Jobs, 1)
+	require.NotNil(t, cfg.Jobs[0].MariaDB)
+	assert.Empty(t, cfg.Jobs[0].MariaDB.BackupMethod)
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -408,12 +408,29 @@ func (s *Scheduler) buildMariaDB(job repository.Job) config.MariaDB {
 	if m.Password != "" {
 		cfg.Password = m.Password
 	}
+	if m.BackupMethod != "" {
+		cfg.BackupMethod = m.BackupMethod
+	}
 	if m.BackupBinary != "" {
 		cfg.BackupBinary = m.BackupBinary
+	} else {
+		cfg.BackupBinary = defaultBinaryForMethod(cfg.BackupMethod)
+	}
+	if m.ClientBinary != "" {
+		cfg.ClientBinary = m.ClientBinary
 	}
 	if m.BackupOptions != "" {
 		cfg.BackupOptions = m.BackupOptions
 	}
 
 	return cfg
+}
+
+func defaultBinaryForMethod(method string) string {
+	switch method {
+	case config.BackupMethodLogical:
+		return "mariadb-dump"
+	default:
+		return "mariadb-backup"
+	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,0 +1,62 @@
+package scheduler_test
+
+import (
+	"testing"
+
+	"github.com/capcom6/mariadb-backup-s3/internal/config"
+	"github.com/capcom6/mariadb-backup-s3/internal/scheduler"
+	"github.com/capcom6/mariadb-backup-s3/internal/scheduler/repository"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildMariaDB_LogicalMethod_DefaultBinary(t *testing.T) {
+	t.Parallel()
+
+	job := repository.Job{
+		MariaDB: &repository.MariaDB{
+			BackupMethod: config.BackupMethodLogical,
+		},
+	}
+
+	cfg := scheduler.BuildMariaDB(job)
+	assert.Equal(t, config.BackupMethodLogical, cfg.BackupMethod)
+	assert.Equal(t, "mariadb-dump", cfg.BackupBinary)
+}
+
+func TestBuildMariaDB_PhysicalMethod_DefaultBinary(t *testing.T) {
+	t.Parallel()
+
+	job := repository.Job{
+		MariaDB: &repository.MariaDB{
+			BackupMethod: config.BackupMethodPhysical,
+		},
+	}
+
+	cfg := scheduler.BuildMariaDB(job)
+	assert.Equal(t, config.BackupMethodPhysical, cfg.BackupMethod)
+	assert.Equal(t, "mariadb-backup", cfg.BackupBinary)
+}
+
+func TestBuildMariaDB_ExplicitBinary_Preserved(t *testing.T) {
+	t.Parallel()
+
+	job := repository.Job{
+		MariaDB: &repository.MariaDB{
+			BackupMethod: config.BackupMethodLogical,
+			BackupBinary: "/opt/custom/mariadb-dump",
+		},
+	}
+
+	cfg := scheduler.BuildMariaDB(job)
+	assert.Equal(t, "/opt/custom/mariadb-dump", cfg.BackupBinary)
+}
+
+func TestBuildMariaDB_NilMariaDB_UsesDefaults(t *testing.T) {
+	t.Parallel()
+
+	job := repository.Job{}
+
+	cfg := scheduler.BuildMariaDB(job)
+	assert.Equal(t, config.DefaultMariaDB().BackupBinary, cfg.BackupBinary)
+	assert.Equal(t, config.DefaultMariaDB().BackupMethod, cfg.BackupMethod)
+}

--- a/internal/storage/filesystem.go
+++ b/internal/storage/filesystem.go
@@ -197,7 +197,7 @@ func (f *filesystemStorage) makePath(filename string) (string, error) {
 	return fullPath, nil
 }
 
-// copyWithContext performs io.Copy with context cancellation support.
+// copyWithContext performs [io.Copy] with context cancellation support.
 func copyWithContext(ctx context.Context, dst io.Writer, src io.Reader) error {
 	const bufferSize = 64 * 1024
 	buf := make([]byte, bufferSize)

--- a/internal/storage/mock.go
+++ b/internal/storage/mock.go
@@ -13,45 +13,45 @@ type MockBackend struct {
 
 func (m *MockBackend) Upload(ctx context.Context, filename string, data io.Reader) error {
 	args := m.Called(ctx, filename, data)
-	return args.Error(0)
+	return args.Error(0) //nolint:wrapcheck // errors must pass through
 }
 
 func (m *MockBackend) Download(ctx context.Context, filename string, data io.Writer) error {
 	args := m.Called(ctx, filename, data)
-	return args.Error(0)
+	return args.Error(0) //nolint:wrapcheck // errors must pass through
 }
 
 func (m *MockBackend) Delete(ctx context.Context, filename string) error {
 	args := m.Called(ctx, filename)
-	return args.Error(0)
+	return args.Error(0) //nolint:wrapcheck // errors must pass through
 }
 
 func (m *MockBackend) List(ctx context.Context) ([]string, error) {
 	args := m.Called(ctx)
 	s, _ := args.Get(0).([]string)
-	return s, args.Error(1)
+	return s, args.Error(1) //nolint:wrapcheck // errors must pass through
 }
 
 func (m *MockBackend) UploadBytes(ctx context.Context, filename string, data []byte) error {
 	args := m.Called(ctx, filename, data)
-	return args.Error(0)
+	return args.Error(0) //nolint:wrapcheck // errors must pass through
 }
 
 func (m *MockBackend) DownloadBytes(ctx context.Context, filename string) ([]byte, error) {
 	args := m.Called(ctx, filename)
 	b, _ := args.Get(0).([]byte)
-	return b, args.Error(1)
+	return b, args.Error(1) //nolint:wrapcheck // errors must pass through
 }
 
 func (m *MockBackend) Lock(ctx context.Context, filename string) (Locker, error) {
 	args := m.Called(ctx, filename)
 	l, _ := args.Get(0).(Locker)
-	return l, args.Error(1)
+	return l, args.Error(1) //nolint:wrapcheck // errors must pass through
 }
 
 func (m *MockBackend) Close() error {
 	args := m.Called()
-	return args.Error(0)
+	return args.Error(0) //nolint:wrapcheck // errors must pass through
 }
 
 type MockLocker struct {
@@ -60,5 +60,5 @@ type MockLocker struct {
 
 func (m *MockLocker) Unlock(ctx context.Context) error {
 	args := m.Called(ctx)
-	return args.Error(0)
+	return args.Error(0) //nolint:wrapcheck // errors must pass through
 }

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -165,9 +165,7 @@ func TestRun_ConcurrentExecution(t *testing.T) {
 
 	// Run pipeline concurrently
 	for range 5 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			var dst bytes.Buffer
 			src := strings.NewReader(input)
 			err := pipeline.Run(context.TODO(), src, &dst, stages...)
@@ -176,7 +174,7 @@ func TestRun_ConcurrentExecution(t *testing.T) {
 				return
 			}
 			results <- dst.String()
-		}()
+		})
 	}
 
 	// Wait for all goroutines to complete
@@ -312,7 +310,7 @@ func TestRun_ErrorStageNumbers(t *testing.T) {
 	}
 }
 
-// Test error wrapping with errors.Is.
+// Test error wrapping with [errors.Is].
 func TestRun_ErrorWrapping(t *testing.T) {
 	// Test that original error is preserved in wrapped error
 	var dst bytes.Buffer

--- a/skills/mariadb-backup-s3/SKILL.md
+++ b/skills/mariadb-backup-s3/SKILL.md
@@ -13,7 +13,8 @@ license: Apache-2.0
 
 # mariadb-backup-s3
 
-CLI tool that runs `mariadb-backup`, compresses (pigz/gzip), optionally encrypts
+CLI tool that backs up MariaDB using either `mariadb-backup` (physical) or
+`mariadb-dump` (logical), compresses (pigz/gzip), optionally encrypts
 (AES-256-GCM), and uploads to S3-compatible, FTP, or local filesystem storage.
 
 ## Subcommands
@@ -38,6 +39,35 @@ mariadb-backup-s3 backup \
   --db-user=backup \
   --retention-count=14 \
   --keep-daily=7
+```
+
+### Logical backup (mariadb-dump)
+
+```shell
+mariadb-backup-s3 backup \
+  --backup-method=mariadb-dump \
+  --storage-url="s3://bucket/path" \
+  --db-host=db.example.com \
+  --db-user=backup
+```
+
+Logical backup dumps each database as a separate `.sql` file, skipping the
+virtual `information_schema` and `performance_schema` schemas. Dumps use
+`mariadb-dump`'s default per-table locking for consistency across all storage
+engines; writes are briefly blocked while each table is dumped. For
+non-blocking dumps (InnoDB only), add `--single-transaction` via
+`MARIADB__BACKUP_OPTIONS`, accepting that non-transactional tables are then
+not guaranteed consistent. Restore by importing the `.sql` files you need:
+
+```shell
+# Extract the backup
+mariadb-backup-s3 restore \
+  --storage-url="s3://bucket/path" \
+  --target-dir=/tmp/restore \
+  --latest
+
+# Import a specific database
+mysql -u root -p < /tmp/restore/mydb.sql
 ```
 
 Minimal (env-only):
@@ -95,7 +125,7 @@ Preview with `--dry-run` before deleting.
 
 ## Requirements
 
-- **External binaries**: `mariadb-backup`, `pigz` (or `gzip`), `tar` — must be in PATH
+- **External binaries**: `mariadb-backup` or `mariadb-dump` — available via PATH or configured full path; `pigz` (or `gzip`), `tar` — must be in PATH
 - **Temp space**: ~2× database size in `$TMPDIR` (default `/tmp`)
 - **Storage**: S3 (AWS SDK v2 — reads `AWS_*` env vars), FTP, or local `file://` URL
 

--- a/skills/mariadb-backup-s3/references/configuration.md
+++ b/skills/mariadb-backup-s3/references/configuration.md
@@ -10,8 +10,10 @@ Config loaded from: CLI flags > env vars > `.env` file (in working directory).
 | `--db-port`, `--port` | `MARIADB__PORT` | `3306` | MariaDB port |
 | `--db-user`, `--user` | `MARIADB__USER` | `root` | MariaDB username |
 | `--db-password`, `--password` | `MARIADB__PASSWORD` | `""` | MariaDB password |
-| `--db-backup-binary` | `MARIADB__BACKUP_BINARY` | `mariadb-backup` | Path to mariabackup binary |
-| `--db-backup-options` | `MARIADB__BACKUP_OPTIONS` | `""` | Extra mariabackup options (sanitized) |
+| `--backup-method` | `MARIADB__BACKUP_METHOD` | `mariadb-backup` | Backup method: `mariadb-backup` (physical) or `mariadb-dump` (logical) |
+| `--db-backup-binary` | `MARIADB__BACKUP_BINARY` | auto-derived | Path to backup binary (auto-derived from `--backup-method` if not set) |
+| `--db-client-binary` | `MARIADB__CLIENT_BINARY` | `mariadb` | Path to mariadb client binary (used to list databases for logical backup) |
+| `--db-backup-options` | `MARIADB__BACKUP_OPTIONS` | `""` | Extra backup options (sanitized) |
 
 ## Storage
 
@@ -102,6 +104,7 @@ MARIADB__HOST=db.example.com
 MARIADB__PORT=3306
 MARIADB__USER=backup
 MARIADB__PASSWORD=secret
+MARIADB__BACKUP_METHOD=mariadb-backup
 
 STORAGE__URL=s3://my-bucket/backups?endpoint=https://s3.eu-west-1.amazonaws.com
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for physical and logical MariaDB backups.
  * Backup methods, binaries, and client settings can be configured through CLI flags, environment variables, and scheduler jobs.
  * Backup binaries are automatically selected when not explicitly configured.
  * Registry entries now record the backup method.
  * Added an example daily logical-backup schedule with seven-backup retention.

* **Documentation**
  * Updated setup, configuration, restore, scheduler, and logical-backup guidance.

* **Tests**
  * Expanded coverage for backup methods, configuration, scheduling, registry metadata, and backup execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->